### PR TITLE
Fix PHPDoc keyword.

### DIFF
--- a/src/Rhumsaa/Uuid/Uuid.php
+++ b/src/Rhumsaa/Uuid/Uuid.php
@@ -157,7 +157,7 @@ final class Uuid
      * as this UUID.
      *
      * @param object $obj
-     * @returns bool
+     * @return bool
      */
     public function equals($obj)
     {


### PR DESCRIPTION
Using the non-standard `@returns` might trigger errors in conjunction
with the `AnnotationReader` from `Doctrine\Common`.
