### PR TITLE
Relax conversion rules.

### DIFF
--- a/src/Rhumsaa/Uuid/Doctrine/UuidType.php
+++ b/src/Rhumsaa/Uuid/Doctrine/UuidType.php
@@ -45,7 +45,7 @@ class UuidType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if (null === $value) {
+        if (empty($value)) {
             return null;
         }
 


### PR DESCRIPTION
Current implementation would not accept empty strings and would
throw exception in that case.
