### PR TITLE
Allow valid Uuid string in Dotrine Type toDatabaseValue conversion

### DIFF
--- a/src/Rhumsaa/Uuid/Doctrine/UuidType.php
+++ b/src/Rhumsaa/Uuid/Doctrine/UuidType.php
@@ -78,6 +78,10 @@ class UuidType extends Type
             return (string) $value;
         }
 
+        if (is_string($value) && Uuid::isValid($value)) {
+            return $value;
+        }
+
         throw ConversionException::conversionFailed($value, self::NAME);
     }
 

--- a/tests/Rhumsaa/Uuid/Doctrine/UuidTypeTest.php
+++ b/tests/Rhumsaa/Uuid/Doctrine/UuidTypeTest.php
@@ -59,6 +59,19 @@ class UuidTypeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Rhumsaa\Uuid\Doctrine\UuidType::convertToDatabaseValue
+     */
+    public function testStringUuidConvertsToDatabaseValue()
+    {
+        $uuid = 'ff6f8cb0-c57d-11e1-9b21-0800200c9a66';
+
+        $expected = $uuid;
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
      * @covers Rhumsaa\Uuid\Doctrine\UuidType::convertToPHPValue
      */
     public function testUuidConvertsToPHPValue()


### PR DESCRIPTION
Made it possible to supply a uuid string value instead of Uuid object to a doctrine field.

This allows for easier migration and makes it possible to pass uuid strings to database look up methods.
