### PR TITLE
added requiresSQLCommentHint true

### DIFF
--- a/src/Rhumsaa/Uuid/Doctrine/UuidType.php
+++ b/src/Rhumsaa/Uuid/Doctrine/UuidType.php
@@ -90,4 +90,14 @@ class UuidType extends Type
     {
         return self::NAME;
     }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @return boolean
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }    
 }


### PR DESCRIPTION
To make Doctrine schema tool able distinguish between this type and string such that it does not try to update the field every time update schema is run.
