### PR TITLE
Correct upper range for mt_rand.

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -1226,7 +1226,7 @@ final class Uuid
 
         $bytes = '';
         foreach (range(1, $length) as $i) {
-            $bytes = chr(mt_rand(0, 256)) . $bytes;
+            $bytes = chr(mt_rand(0, 255)) . $bytes;
         }
 
         return $bytes;


### PR DESCRIPTION
Double checked with #php.security and @ircmaxell chimed in to agree that this should be changed.
