### PR TITLE
Add COMB generator for use with UUID4

### DIFF
--- a/src/Generator/CombGenerator.php
+++ b/src/Generator/CombGenerator.php
@@ -33,7 +33,7 @@ class CombGenerator implements RandomGeneratorInterface
         }
 
         $hash = $this->randomGenerator->generate($length - 6);
-        $lsbTime = hexdec(substr(dechex(round(microtime(true) * 10000, 0)), -12));
+        $lsbTime = substr(round(microtime(true) * 10000, 0), -6);
 
         return $hash . $lsbTime;
     }

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -808,10 +808,13 @@ class UuidTest extends TestCase
         $previous = $factory->uuid4();
 
         for ($i = 0; $i < 100; $i ++) {
-            // Just to make sure we dont generate more than one UUID / ms for the purpose of this test.
-            usleep(5000);
+            // Just to make sure we dont generate more than one UUID / s for the purpose of this test.
+            usleep(1000);
+
             $uuid = $factory->uuid4();
             $this->assertGreaterThan($previous->toString(), $uuid->toString());
+
+            $previous = $uuid;
         }
     }
 


### PR DESCRIPTION
Allows to generate COMB sequential UUID's per #40 & #2 

No extra factory method is added, in order to generate a COMB style UUID, a CombGenerator instance has to be injected in a UuidFactory instance, which will then return COMB UUID's via uuid4().
