### PR TITLE
Add PECL based UUID factory for UUID1/4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 before_script:
   - composer self-update
   - composer install --dev --prefer-source
+  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then pecl install uuid; fi;'
 
 script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ before_script:
   - composer self-update
   - composer install --dev --prefer-source
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then printf "\n" | pecl install uuid; fi;'
+  - phpenv rehash
 
 script:
-  - ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml tests/PeclUuidTest.php
   - ./vendor/bin/phpcs --standard=phpcs.xml ./
 
 after_script: php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - phpenv rehash
 
 script:
-  - ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml tests/PeclUuidTest.php
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
   - ./vendor/bin/phpcs --standard=phpcs.xml ./
 
 after_script: php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ php:
   - 5.6
   - hhvm
 
+before_install:
+  - sudo apt-get update && sudo apt-get install uuid-dev
+
 before_script:
   - composer self-update
   - composer install --dev --prefer-source
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then pecl install uuid; fi;'
+  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then printf "\n" | pecl install uuid; fi;'
 
 script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml

--- a/src/PeclUuidFactory.php
+++ b/src/PeclUuidFactory.php
@@ -33,6 +33,14 @@ class PeclUuidFactory implements UuidFactoryInterface
     }
 
     /**
+     * Forces factory to act as if PECL extension is not available
+     */
+    public function disablePecl()
+    {
+        $this->hasExt = false;
+    }
+
+    /**
      * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::uuid1()
      */
     public function uuid1($node = null, $clockSeq = null)

--- a/src/PeclUuidFactory.php
+++ b/src/PeclUuidFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Rhumsaa\Uuid;
+
+class PeclUuidFactory implements UuidFactoryInterface
+{
+
+    private $factory;
+
+    public function __construct(UuidFactoryInterface $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /*
+     * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::uuid1()
+     */
+    public function uuid1($node = null, $clockSeq = null)
+    {
+        $uuid = uuid_create(UUID_TYPE_TIME);
+
+        return $this->fromString($uuid);
+    }
+
+    /*
+     * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::uuid3()
+     */
+    public function uuid3($ns, $name)
+    {
+        return $this->factory->uuid3($ns, $name);
+    }
+
+    /*
+     * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::uuid4()
+     */
+    public function uuid4()
+    {
+        $uuid = uuid_create(UUID_TYPE_RANDOM);
+
+        return $this->fromString($uuid);
+    }
+
+    /*
+     * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::uuid5()
+     */
+    public function uuid5($ns, $name)
+    {
+        return $this->factory->uuid5($ns, $name);
+    }
+
+    /*
+     * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::fromBytes()
+     */
+    public function fromBytes($bytes)
+    {
+        return $this->factory->fromBytes($bytes);
+    }
+
+    /*
+     * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::fromString()
+     */
+    public function fromString($name)
+    {
+        return $this->factory->fromString($name);
+    }
+
+    /*
+     * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::fromInteger()
+     */
+    public function fromInteger($integer)
+    {
+        return $this->factory->fromInteger($integer);
+    }
+}

--- a/src/PeclUuidFactory.php
+++ b/src/PeclUuidFactory.php
@@ -2,27 +2,50 @@
 
 namespace Rhumsaa\Uuid;
 
+/**
+ * Factory relying on PECL UUID library whenever possible, otherwise defaulting
+ * to pure PHP factory.
+ * @author thibaud
+ *
+ */
 class PeclUuidFactory implements UuidFactoryInterface
 {
-
+    /**
+     *
+     * @var UuidFactoryInterface
+     */
     private $factory;
 
+    /**
+     *
+     * @var boolean
+     */
+    private $hasExt = false;
+
+    /**
+     *
+     * @param UuidFactoryInterface $factory
+     */
     public function __construct(UuidFactoryInterface $factory)
     {
+        $this->hasExt = extension_loaded('uuid');
         $this->factory = $factory;
     }
 
-    /*
+    /**
      * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::uuid1()
      */
     public function uuid1($node = null, $clockSeq = null)
     {
-        $uuid = uuid_create(UUID_TYPE_TIME);
+        if (! $this->hasExt || $node !== null || $clockSeq !== null) {
+            // If either param is not null, we cannot use PECL without breaking LSP.
+            return $this->factory->uuid1($node, $clockSeq);
+        }
 
-        return $this->fromString($uuid);
+        return $this->fromString(uuid_create(UUID_TYPE_TIME));
     }
 
-    /*
+    /**
      * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::uuid3()
      */
     public function uuid3($ns, $name)
@@ -30,17 +53,19 @@ class PeclUuidFactory implements UuidFactoryInterface
         return $this->factory->uuid3($ns, $name);
     }
 
-    /*
+    /**
      * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::uuid4()
      */
     public function uuid4()
     {
-        $uuid = uuid_create(UUID_TYPE_RANDOM);
+        if (! $this->hasExt) {
+            return $this->factory->uuid4();
+        }
 
-        return $this->fromString($uuid);
+        return $this->fromString(uuid_create(UUID_TYPE_RANDOM));
     }
 
-    /*
+    /**
      * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::uuid5()
      */
     public function uuid5($ns, $name)
@@ -48,7 +73,7 @@ class PeclUuidFactory implements UuidFactoryInterface
         return $this->factory->uuid5($ns, $name);
     }
 
-    /*
+    /**
      * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::fromBytes()
      */
     public function fromBytes($bytes)
@@ -56,7 +81,7 @@ class PeclUuidFactory implements UuidFactoryInterface
         return $this->factory->fromBytes($bytes);
     }
 
-    /*
+    /**
      * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::fromString()
      */
     public function fromString($name)
@@ -64,7 +89,7 @@ class PeclUuidFactory implements UuidFactoryInterface
         return $this->factory->fromString($name);
     }
 
-    /*
+    /**
      * (non-PHPdoc) @see \Rhumsaa\Uuid\UuidFactoryInterface::fromInteger()
      */
     public function fromInteger($integer)

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -99,7 +99,7 @@ class Uuid implements UuidInterface, \JsonSerializable
 
     /**
      *
-     * @var UuidFactory
+     * @var UuidFactoryInterface
      */
     private static $factory = null;
 
@@ -725,7 +725,7 @@ class Uuid implements UuidInterface, \JsonSerializable
         return self::$factory;
     }
 
-    public static function setFactory(UuidFactory $factory)
+    public static function setFactory(UuidFactoryInterface $factory)
     {
         self::$factory = $factory;
     }

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -719,7 +719,7 @@ class Uuid implements UuidInterface, \JsonSerializable
     public static function getFactory()
     {
         if (! self::$factory) {
-            self::$factory = new UuidFactory();
+            self::$factory = new PeclUuidFactory(new UuidFactory());
         }
 
         return self::$factory;

--- a/src/UuidFactory.php
+++ b/src/UuidFactory.php
@@ -8,7 +8,7 @@ use Rhumsaa\Uuid\Converter\TimeConverterInterface;
 use Rhumsaa\Uuid\Provider\NodeProviderInterface;
 use Rhumsaa\Uuid\Provider\TimeProviderInterface;
 
-class UuidFactory
+class UuidFactory implements UuidFactoryInterface
 {
 
     /**

--- a/src/UuidFactoryInterface.php
+++ b/src/UuidFactoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rhumsaa\Uuid;
+
+interface UuidFactoryInterface
+{
+    public function uuid1($node = null, $clockSeq = null);
+
+    public function uuid3($ns, $name);
+
+    public function uuid4();
+
+    public function uuid5($ns, $name);
+
+    public function fromBytes($bytes);
+
+    public function fromString($name);
+
+    public function fromInteger($integer);
+
+}

--- a/tests/PeclUuidTest.php
+++ b/tests/PeclUuidTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rhumsaa\Uuid;
+
+use Rhumsaa\Uuid\Provider\Time\SystemTimeProvider;
+use Rhumsaa\Uuid\Provider\Time\FixedTimeProvider;
+use Rhumsaa\Uuid\Generator\CombGenerator;
+
+class PeclUuidTest extends UuidTest
+{
+    protected function setUp()
+    {
+        Uuid::setFactory(new PeclUuidFactory(new UuidFactory()));
+
+        RandomGeneratorFactory::$forceNoOpensslRandomPseudoBytes = false;
+    }
+}

--- a/tests/PeclUuidTest.php
+++ b/tests/PeclUuidTest.php
@@ -37,9 +37,6 @@ class PeclUuidTest extends \PHPUnit_Framework_TestCase
      */
     public function testUuid1WithParametersIsDelegated($node, $clockSeq)
     {
-        $node = true;
-        $clockSeq = null;
-
         $this->mockFactory->expects($this->once())
             ->method('uuid1')
             ->with($node, $clockSeq);

--- a/tests/PeclUuidTest.php
+++ b/tests/PeclUuidTest.php
@@ -2,16 +2,126 @@
 
 namespace Rhumsaa\Uuid;
 
-use Rhumsaa\Uuid\Provider\Time\SystemTimeProvider;
-use Rhumsaa\Uuid\Provider\Time\FixedTimeProvider;
-use Rhumsaa\Uuid\Generator\CombGenerator;
-
-class PeclUuidTest extends UuidTest
+class PeclUuidTest extends \PHPUnit_Framework_TestCase
 {
+    private $mockFactory;
+
+    public static $mockNoExt = false;
+
     protected function setUp()
+    {
+        $this->mockFactory = $this->getMock('Rhumsaa\Uuid\UuidFactoryInterface');
+
+        if (! function_exists('\Rhumsaa\Uuid\extension_loaded')) {
+            // Hackish, but allows mocking extension not avail without
+            // breaking the function if tests are loaded accidently in non test env.
+            eval('namespace Rhumsaa\Uuid { function extension_loaded($name) {
+                return ! PeclUuidTest::$mockNoExt;
+            } }');
+        }
+
+        Uuid::setFactory(new PeclUuidFactory($this->mockFactory));
+    }
+
+    public function getUuid1Params()
+    {
+        return [
+            [ true, null ],
+            [ null, true ],
+            [ true, true ]
+        ];
+    }
+
+    /**
+     * @dataProvider getUuid1Params
+     */
+    public function testUuid1WithParametersIsDelegated($node, $clockSeq)
+    {
+        $node = true;
+        $clockSeq = null;
+
+        $this->mockFactory->expects($this->once())
+            ->method('uuid1')
+            ->with($node, $clockSeq);
+
+        Uuid::uuid1($node, $clockSeq);
+    }
+
+    public function testUuid1WithoutParametersIsNotDelegated()
+    {
+        $this->mockFactory->expects($this->never())
+            ->method('uuid1');
+
+        Uuid::uuid1();
+    }
+
+    public function testUuid1WithoutExtensionIsDelegated()
+    {
+        self::$mockNoExt = true;
+
+        Uuid::setFactory(new PeclUuidFactory($this->mockFactory));
+
+        $this->mockFactory->expects($this->once())
+            ->method('uuid1');
+
+        Uuid::uuid1();
+
+        self::$mockNoExt = false;
+    }
+
+    public function testUuid1Version()
     {
         Uuid::setFactory(new PeclUuidFactory(new UuidFactory()));
 
-        RandomGeneratorFactory::$forceNoOpensslRandomPseudoBytes = false;
+        $uuid = Uuid::uuid1();
+
+        $this->assertEquals(1, $uuid->getVersion());
+    }
+
+    public function testUuid3IsDelegated()
+    {
+        $this->mockFactory->expects($this->once())
+            ->method('uuid3');
+
+        Uuid::uuid3(Uuid::NAMESPACE_DNS, str_replace('\\', '.', __NAMESPACE__));
+    }
+
+    public function testUuid4WithoutExtensionIsDelegated()
+    {
+        self::$mockNoExt = true;
+
+        Uuid::setFactory(new PeclUuidFactory($this->mockFactory));
+
+        $this->mockFactory->expects($this->once())
+            ->method('uuid4');
+
+        Uuid::uuid4();
+
+        self::$mockNoExt = false;
+    }
+
+    public function testUuid4WithParametersIsNeverDelegated()
+    {
+        $this->mockFactory->expects($this->never())
+            ->method('uuid4');
+
+        Uuid::uuid4();
+    }
+
+    public function testUuid4Version()
+    {
+        Uuid::setFactory(new PeclUuidFactory(new UuidFactory()));
+
+        $uuid = Uuid::uuid4();
+
+        $this->assertEquals(4, $uuid->getVersion());
+    }
+
+    public function testUuid5IsDelegated()
+    {
+        $this->mockFactory->expects($this->once())
+            ->method('uuid5');
+
+        Uuid::uuid5(Uuid::NAMESPACE_DNS, str_replace('\\', '.', __NAMESPACE__));
     }
 }

--- a/tests/PeclUuidTest.php
+++ b/tests/PeclUuidTest.php
@@ -6,19 +6,9 @@ class PeclUuidTest extends \PHPUnit_Framework_TestCase
 {
     private $mockFactory;
 
-    public static $mockNoExt = false;
-
     protected function setUp()
     {
         $this->mockFactory = $this->getMock('Rhumsaa\Uuid\UuidFactoryInterface');
-
-        if (! function_exists('\Rhumsaa\Uuid\extension_loaded')) {
-            // Hackish, but allows mocking extension not avail without
-            // breaking the function if tests are loaded accidently in non test env.
-            eval('namespace Rhumsaa\Uuid { function extension_loaded($name) {
-                return ! PeclUuidTest::$mockNoExt;
-            } }');
-        }
 
         Uuid::setFactory(new PeclUuidFactory($this->mockFactory));
     }
@@ -54,16 +44,15 @@ class PeclUuidTest extends \PHPUnit_Framework_TestCase
 
     public function testUuid1WithoutExtensionIsDelegated()
     {
-        self::$mockNoExt = true;
+        $factory = new PeclUuidFactory($this->mockFactory);
+        $factory->disablePecl();
 
-        Uuid::setFactory(new PeclUuidFactory($this->mockFactory));
+        Uuid::setFactory($factory);
 
         $this->mockFactory->expects($this->once())
             ->method('uuid1');
 
         Uuid::uuid1();
-
-        self::$mockNoExt = false;
     }
 
     public function testUuid1Version()
@@ -85,16 +74,15 @@ class PeclUuidTest extends \PHPUnit_Framework_TestCase
 
     public function testUuid4WithoutExtensionIsDelegated()
     {
-        self::$mockNoExt = true;
+        $factory = new PeclUuidFactory($this->mockFactory);
+        $factory->disablePecl();
 
-        Uuid::setFactory(new PeclUuidFactory($this->mockFactory));
+        Uuid::setFactory($factory);
 
         $this->mockFactory->expects($this->once())
             ->method('uuid4');
 
         Uuid::uuid4();
-
-        self::$mockNoExt = false;
     }
 
     public function testUuid4WithParametersIsNeverDelegated()

--- a/tests/PeclUuidTest.php
+++ b/tests/PeclUuidTest.php
@@ -36,6 +36,10 @@ class PeclUuidTest extends \PHPUnit_Framework_TestCase
 
     public function testUuid1WithoutParametersIsNotDelegated()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('PECL Uuid extension not available in HHVM');
+        }
+
         $this->mockFactory->expects($this->never())
             ->method('uuid1');
 
@@ -87,6 +91,10 @@ class PeclUuidTest extends \PHPUnit_Framework_TestCase
 
     public function testUuid4WithParametersIsNeverDelegated()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('PECL Uuid extension not available in HHVM');
+        }
+
         $this->mockFactory->expects($this->never())
             ->method('uuid4');
 


### PR DESCRIPTION
As suggested in #31 

Defaults to using PECL when available, fallsback to PHP factory when extension is not available, or when it is not possible to conform to the interface (parameters declared in uuid1(...) interface are not available via PECL.

Design choices (decorator instead of composing the existing factory) may be questionnable, but it gets the job done transparently, and honestly, laziness.