### PR TITLE
"passthru" replacement for "backtick operator" / getNodeFromSystem once per runtime 

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -1134,20 +1134,21 @@ final class Uuid
      */
     protected static function getIfconfig()
     {
+        ob_start();
         switch (strtoupper(substr(php_uname('a'), 0, 3))) {
             case 'WIN':
-                $ifconfig = `ipconfig /all 2>&1`;
+                passthru('ipconfig /all 2>&1');
                 break;
             case 'DAR':
-                $ifconfig = `ifconfig 2>&1`;
+                passthru('ifconfig 2>&1');
                 break;
             case 'LIN':
             default:
-                $ifconfig = `netstat -ie 2>&1`;
+                passthru('netstat -ie 2>&1');
                 break;
         }
 
-        return $ifconfig;
+        return ob_get_clean();
     }
 
     /**
@@ -1162,7 +1163,12 @@ final class Uuid
      */
     protected static function getNodeFromSystem()
     {
-        $node = null;
+        static $node = null;
+        
+        if($node !== null) {
+            return $node;
+        }
+        
         $pattern = '/[^:]([0-9A-Fa-f]{2}([:-])[0-9A-Fa-f]{2}(\2[0-9A-Fa-f]{2}){4})[^:]/';
         $matches = array();
 


### PR DESCRIPTION
- change method "getIfconfig()" to use "passthru()" and an output buffer instead of the "backtick operator" which may be disabled for security reasons
- change  method "getNodeFromSystem()" to process detection only once per runtime - because of great performance impact
(Test: generate 100 UUIDs[v1] before ~21s / after ~200ms)