### PR TITLE
Updated readme to show correct composer require command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ the following command to install the package and add it as a requirement to
 `composer.json`:
 
 ```bash
-composer require ramsey/uuid
+composer require ramsey/uuid "3.0.*@dev"
 ```
 
 


### PR DESCRIPTION
The old composer command pulled down the old "rhumsaa/uuid" version which didn't match the documentation.