### PR TITLE
composer.phar require "rhumsaa/uuid=~2.8" is not proper

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ the following command to install the package and add it as a requirement to
 `composer.json`:
 
 ```bash
-composer.phar require "rhumsaa/uuid=~2.8"
+composer.phar require "ramsey/uuid=~2.8"
 ```
 
 


### PR DESCRIPTION
Then running

    composer.phar require "rhumsaa/uuid=~2.8"

said:

    Package rhumsaa/uuid is abandoned, you should avoid using it. Use ramsey/uuid instead.

so should change it to 

    composer.phar require "ramsey/uuid=~2.8"