### PR TITLE
Time generator improvements

### DIFF
--- a/src/FeatureSet.php
+++ b/src/FeatureSet.php
@@ -15,6 +15,7 @@
 namespace Ramsey\Uuid;
 
 use Ramsey\Uuid\Converter\TimeConverterInterface;
+use Ramsey\Uuid\Generator\PeclUuidTimeGenerator;
 use Ramsey\Uuid\Provider\Node\FallbackNodeProvider;
 use Ramsey\Uuid\Provider\Node\RandomNodeProvider;
 use Ramsey\Uuid\Provider\Node\SystemNodeProvider;
@@ -153,6 +154,10 @@ class FeatureSet
 
     protected function buildTimeGenerator(TimeProviderInterface $timeProvider)
     {
+        if ($this->enablePecl) {
+            return new PeclUuidTimeGenerator();
+        }
+
         return (new TimeGeneratorFactory(
             $this->nodeProvider,
             $this->buildTimeConverter(),

--- a/src/Generator/TimeGeneratorFactory.php
+++ b/src/Generator/TimeGeneratorFactory.php
@@ -14,26 +14,43 @@
 
 namespace Ramsey\Uuid\Generator;
 
-use Ramsey\Uuid\FeatureSet;
+use Ramsey\Uuid\Converter\TimeConverterInterface;
+use Ramsey\Uuid\Provider\NodeProviderInterface;
+use Ramsey\Uuid\Provider\TimeProviderInterface;
 
 class TimeGeneratorFactory
 {
     /**
-     * @var FeatureSet
+     * @var NodeProviderInterface
      */
-    private $featureSet;
+    private $nodeProvider;
 
-    public function __construct(FeatureSet $featureSet)
-    {
-        $this->featureSet = $featureSet;
+    /**
+     * @var TimeConverterInterface
+     */
+    private $timeConverter;
+
+    /**
+     * @var TimeProviderInterface
+     */
+    private $timeProvider;
+
+    public function __construct(
+        NodeProviderInterface $nodeProvider,
+        TimeConverterInterface $timeConverter,
+        TimeProviderInterface $timeProvider
+    ) {
+        $this->nodeProvider = $nodeProvider;
+        $this->timeConverter = $timeConverter;
+        $this->timeProvider = $timeProvider;
     }
 
     public function getGenerator()
     {
         return new DefaultTimeGenerator(
-            $this->featureSet->getNodeProvider(),
-            $this->featureSet->getTimeConverter(),
-            $this->featureSet->getTimeProvider()
+            $this->nodeProvider,
+            $this->timeConverter,
+            $this->timeProvider
         );
     }
 }

--- a/src/UuidFactory.php
+++ b/src/UuidFactory.php
@@ -16,9 +16,7 @@ namespace Ramsey\Uuid;
 
 use InvalidArgumentException;
 use Ramsey\Uuid\Converter\NumberConverterInterface;
-use Ramsey\Uuid\Converter\TimeConverterInterface;
 use Ramsey\Uuid\Provider\NodeProviderInterface;
-use Ramsey\Uuid\Provider\TimeProviderInterface;
 use Ramsey\Uuid\Generator\RandomGeneratorInterface;
 use Ramsey\Uuid\Generator\TimeGeneratorInterface;
 use Ramsey\Uuid\Codec\CodecInterface;
@@ -57,18 +55,6 @@ class UuidFactory implements UuidFactoryInterface
 
     /**
      *
-     * @var TimeConverterInterface
-     */
-    private $timeConverter = null;
-
-    /**
-     *
-     * @var TimeProviderInterface
-     */
-    private $timeProvider = null;
-
-    /**
-     *
      * @var UuidBuilderInterface
      */
     private $uuidBuilder = null;
@@ -86,8 +72,6 @@ class UuidFactory implements UuidFactoryInterface
         $this->numberConverter = $features->getNumberConverter();
         $this->randomGenerator = $features->getRandomGenerator();
         $this->timeGenerator = $features->getTimeGenerator();
-        $this->timeConverter = $features->getTimeConverter();
-        $this->timeProvider = $features->getTimeProvider();
         $this->uuidBuilder = $features->getBuilder();
     }
 
@@ -111,19 +95,14 @@ class UuidFactory implements UuidFactoryInterface
         return $this->timeGenerator;
     }
 
+    public function setTimeGenerator(TimeGeneratorInterface $generator)
+    {
+        $this->timeGenerator = $generator;
+    }
+
     public function getNumberConverter()
     {
         return $this->numberConverter;
-    }
-
-    public function getTimeConverter()
-    {
-        return $this->timeConverter;
-    }
-
-    public function getTimeProvider()
-    {
-        return $this->timeProvider;
     }
 
     public function setRandomGenerator(RandomGeneratorInterface $generator)


### PR DESCRIPTION
- Add option to enable PeclUuidTimeGenerator via FeatureSet
- Enable use of custom TimeGenerator implementations
  - Removes now unnecessary `timeConverter` and `timeProvider`
    properties, setters, and getters in both FeatureSet and
    UuidFactory as those are now exclusively used by the default
    TimeGenerator
  - Adds a `setTimeGenerator` method on UuidFactory to override the
    default time generator