### PR TITLE
Remove unnecessary conversions in BigNumberConverter

### DIFF
--- a/src/Converter/Number/BigNumberConverter.php
+++ b/src/Converter/Number/BigNumberConverter.php
@@ -23,7 +23,7 @@ class BigNumberConverter implements NumberConverterInterface
      */
     public function fromHex($hex)
     {
-        $number = \Moontoast\Math\BigNumber::baseConvert($hex, 16, 10);
+        $number = \Moontoast\Math\BigNumber::convertToBase10($hex, 16);
 
         return new \Moontoast\Math\BigNumber($number);
     }
@@ -34,6 +34,6 @@ class BigNumberConverter implements NumberConverterInterface
             $integer = new \Moontoast\Math\BigNumber($integer);
         }
 
-        return \Moontoast\Math\BigNumber::baseConvert($integer, 10, 16);
+        return \Moontoast\Math\BigNumber::convertFromBase10($integer, 16);
     }
 }


### PR DESCRIPTION
Calling the BigNumber::baseConvert method uses two consecutive convert operations:
  - BigNumber::convertToBase10
  - BigNumber::convertFromBase10

In BigNumberConverter's context, we can directly call each specific method to avoid
the conversion overhead (and improve performance by a very tiny little bit).