### PR TITLE
Improve GUID support

### DIFF
--- a/src/Codec/GuidStringCodec.php
+++ b/src/Codec/GuidStringCodec.php
@@ -51,16 +51,17 @@ class GuidStringCodec extends StringCodec
 
     public function decodeBytes($bytes)
     {
+        // Specifically call parent::decode to preserve correct byte order
         return parent::decode(bin2hex($bytes));
     }
 
     protected function swapFields(array & $components)
     {
-        $hex = unpack('H*', pack('V', hexdec($components[0])));
+        $hex = unpack('H*', pack('L', hexdec($components[0])));
         $components[0] = $hex[1];
-        $hex = unpack('H*', pack('v', hexdec($components[1])));
+        $hex = unpack('H*', pack('S', hexdec($components[1])));
         $components[1] = $hex[1];
-        $hex = unpack('H*', pack('v', hexdec($components[2])));
+        $hex = unpack('H*', pack('S', hexdec($components[2])));
         $components[2] = $hex[1];
     }
 }

--- a/src/FeatureSet.php
+++ b/src/FeatureSet.php
@@ -42,11 +42,6 @@ use Ramsey\Uuid\Provider\TimeProviderInterface;
 class FeatureSet
 {
 
-    public static function isLittleEndianSystem()
-    {
-        return current(unpack('v', pack('S', 0x00FF))) === 0x00FF;
-    }
-
     private $disableBigNumber = false;
 
     private $disable64Bit = false;
@@ -124,7 +119,7 @@ class FeatureSet
 
     protected function buildCodec($useGuids = false)
     {
-        if ($useGuids && $this->isLittleEndianSystem()) {
+        if ($useGuids) {
             return new GuidStringCodec($this->builder);
         }
 

--- a/src/FeatureSet.php
+++ b/src/FeatureSet.php
@@ -42,6 +42,11 @@ use Ramsey\Uuid\Provider\TimeProviderInterface;
 class FeatureSet
 {
 
+    public static function isLittleEndianSystem()
+    {
+        return current(unpack('v', pack('S', 0x00FF))) === 0x00FF;
+    }
+
     private $disableBigNumber = false;
 
     private $disable64Bit = false;
@@ -119,7 +124,7 @@ class FeatureSet
 
     protected function buildCodec($useGuids = false)
     {
-        if ($useGuids) {
+        if ($useGuids && $this->isLittleEndianSystem()) {
             return new GuidStringCodec($this->builder);
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,4 +25,22 @@ class TestCase extends \PHPUnit_Framework_TestCase
     {
         return class_exists('Moontoast\\Math\\BigNumber');
     }
+
+    protected function skipIfLittleEndianHost()
+    {
+        if (FeatureSet::isLittleEndianSystem()) {
+            $this->markTestSkipped(
+                'Skipping test targeting big-endian architectures.'
+            );
+        }
+    }
+
+    protected function skipIfBigEndianHost()
+    {
+        if (! FeatureSet::isLittleEndianSystem()) {
+            $this->markTestSkipped(
+                'Skipping test targeting little-endian architectures.'
+            );
+        }
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,7 +28,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function skipIfLittleEndianHost()
     {
-        if (FeatureSet::isLittleEndianSystem()) {
+        if (self::isLittleEndianSystem()) {
             $this->markTestSkipped(
                 'Skipping test targeting big-endian architectures.'
             );
@@ -37,10 +37,15 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function skipIfBigEndianHost()
     {
-        if (! FeatureSet::isLittleEndianSystem()) {
+        if (! self::isLittleEndianSystem()) {
             $this->markTestSkipped(
                 'Skipping test targeting little-endian architectures.'
             );
         }
+    }
+
+    public static function isLittleEndianSystem()
+    {
+        return current(unpack('v', pack('S', 0x00FF))) === 0x00FF;
     }
 }

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -26,6 +26,7 @@ class UuidTest extends TestCase
     }
 
     /**
+     * Tests that UUID and GUID's have the same textual representation but not the same binary representation.
      */
     public function testFromLittleEndianString()
     {
@@ -38,7 +39,8 @@ class UuidTest extends TestCase
         $this->assertInstanceOf('\Ramsey\Uuid\Uuid', $guid);
         // UUID's and GUID's share the same textual representation
         $this->assertEquals($uuid->toString(), $guid->toString());
-        // But not the same binary representation
+        // But not the same binary representation (this assertion is valid on little endian hosts
+        // only)
         $this->assertNotEquals(bin2hex($uuid->getBytes()), bin2hex($guid->getBytes()));
     }
 

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -28,8 +28,10 @@ class UuidTest extends TestCase
     /**
      * Tests that UUID and GUID's have the same textual representation but not the same binary representation.
      */
-    public function testFromLittleEndianString()
+    public function testFromGuidStringOnLittleEndianHost()
     {
+        $this->skipIfBigEndianHost();
+
         $uuid = Uuid::fromString('b08c6fff-7dc5-e111-9b21-0800200c9a66');
 
         Uuid::setFactory(new UuidFactory(new FeatureSet(true)));
@@ -42,6 +44,28 @@ class UuidTest extends TestCase
         // But not the same binary representation (this assertion is valid on little endian hosts
         // only)
         $this->assertNotEquals(bin2hex($uuid->getBytes()), bin2hex($guid->getBytes()));
+    }
+
+    /**
+     * Tests that UUID and GUID's have the same textual representation and the same binary representation.
+     * This test is only valid on big endian hosts.
+     */
+    public function testFromGuidStringOnBigEndianHost()
+    {
+        $this->skipIfLittleEndianHost();
+
+        $uuid = Uuid::fromString('b08c6fff-7dc5-e111-9b21-0800200c9a66');
+
+        Uuid::setFactory(new UuidFactory(new FeatureSet(true)));
+
+        $guid = Uuid::fromString('b08c6fff-7dc5-e111-9b21-0800200c9a66');
+
+        $this->assertInstanceOf('\Ramsey\Uuid\Uuid', $guid);
+        // UUID's and GUID's share the same textual representation
+        $this->assertEquals($uuid->toString(), $guid->toString());
+        // But not the same binary representation (this assertion is valid on little endian hosts
+        // only)
+        $this->assertEquals(bin2hex($uuid->getBytes()), bin2hex($guid->getBytes()));
     }
 
     /**
@@ -1376,8 +1400,10 @@ class UuidTest extends TestCase
         $this->assertTrue($uuid->equals($fromBytesUuid));
     }
 
-    public function testFromLittleEndianBytes()
+    public function testFromGuidBytesOnLittleEndianHost()
     {
+        $this->skipIfBigEndianHost();
+
         $uuidFactory = new UuidFactory(new FeatureSet(false));
         $guidFactory = new UuidFactory(new FeatureSet(true));
 
@@ -1391,6 +1417,29 @@ class UuidTest extends TestCase
         $this->assertEquals('b08c6fff-7dc5-e111-9b21-0800200c9a66', $guid->toString());
 
         // Check that parsing LE bytes as LE preserves fields
+        $guid = $guidFactory->fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
+        $bytes = $guid->getBytes();
+
+        $parsedGuid = $guidFactory->fromBytes($bytes);
+
+        $this->assertEquals($guid->toString(), $parsedGuid->toString());
+    }
+
+    public function testFromGuidBytesOnBigEndianHost()
+    {
+        $this->skipIfLittleEndianHost();
+
+        $uuidFactory = new UuidFactory(new FeatureSet(false));
+        $guidFactory = new UuidFactory(new FeatureSet(true));
+
+        $uuid = $uuidFactory->fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
+        $bytes = $uuid->getBytes();
+
+        $guid = $guidFactory->fromBytes($bytes);
+
+        // UUIDs and GUIDs should have the same binary representation on BE hosts
+        $this->assertEquals($uuid->toString(), $guid->toString());
+
         $guid = $guidFactory->fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
         $bytes = $guid->getBytes();
 


### PR DESCRIPTION
As mentionned in #75, GUID binary representations are a bit peculiar:

- On little endian (LE) architectures, the byte order of the first three fields is LE
- On big endian (BE) architectures, it is the same as a GUID
- String representation is always the same

GUID related tests had to be updated and split based on host endianness in order to assert that:

- Binary representation of a GUID is different than the UUID one on LE hosts, but string representation is the same
- Binary representation of GUIDs and UUIDs is identical on BE hosts

It's unfortunately impossible to fully test these changes on Travis CI, so you'll have to take my word that it works (or [build your own BE virtual machine](https://gist.github.com/aztech-dev/f57258e367ceb6edd100) and run the tests yourself).