### PR TITLE
Better random number generator for UUID v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,15 @@
         "phpunit/phpunit": "~4.1",
         "satooshi/php-coveralls": "~0.6",
         "squizlabs/php_codesniffer": "^2.3",
-        "jakub-onderka/php-parallel-lint": "^0.9.0"
+        "jakub-onderka/php-parallel-lint": "^0.9.0",
+        "ircmaxell/random-lib": "^1.1"
     },
     "bin": ["bin/uuid"],
     "suggest": {
         "moontoast/math": "Support for converting UUID to 128-bit integer (in string form).",
         "symfony/console": "Support for use of the bin/uuid command line tool.",
-        "doctrine/dbal": "Allow the use of a UUID as doctrine field type."
+        "doctrine/dbal": "Allow the use of a UUID as doctrine field type.",
+        "ircmaxell/random-lib": "Better random number generator for UUID v4"
     },
     "autoload": {
         "psr-4": {"Rhumsaa\\Uuid\\": "src/"}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,6 +39,15 @@ class TestCase extends \PHPUnit_Framework_TestCase
         }
     }
 
+    protected function skipIfNoRandomNumberGenerator()
+    {
+        if (!$this->hasRandomNumberGenerator()) {
+            $this->markTestSkipped(
+                'Skipping test that requires ircmaxell/random-lib.'
+            );
+        }
+    }
+
     protected function hasMoontoastMath()
     {
         return class_exists('Moontoast\\Math\\BigNumber');
@@ -52,5 +61,10 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function hasDoctrineDbal()
     {
         return class_exists('Doctrine\\DBAL\\Types\\Type');
+    }
+
+    protected function hasRandomNumberGenerator()
+    {
+        return class_exists('RandomLib\\Generator');
     }
 }

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -9,7 +9,9 @@ class UuidTest extends TestCase
         Uuid::$force32Bit = false;
         Uuid::$forceNoBigNumber = false;
         Uuid::$forceNoOpensslRandomPseudoBytes = false;
+        Uuid::$forceNoRandomNumberGenerator = false;
         Uuid::$ignoreSystemNode = false;
+        Uuid::$randomNumberGenerator = null;
     }
 
     /**
@@ -826,9 +828,40 @@ class UuidTest extends TestCase
      * @covers Rhumsaa\Uuid\Uuid::generateBytes
      * @covers Rhumsaa\Uuid\Uuid::uuidFromHashedName
      */
+    public function testUuid4WithoutRandomNumberGenerator()
+    {
+        $this->skipIfNoRandomNumberGenerator();
+        Uuid::$forceNoRandomNumberGenerator = true;
+        $uuid = Uuid::uuid4();
+        $this->assertInstanceOf('Rhumsaa\Uuid\Uuid', $uuid);
+        $this->assertEquals(2, $uuid->getVariant());
+        $this->assertEquals(4, $uuid->getVersion());
+    }
+
+    /**
+     * @covers Rhumsaa\Uuid\Uuid::uuid4
+     * @covers Rhumsaa\Uuid\Uuid::generateBytes
+     * @covers Rhumsaa\Uuid\Uuid::uuidFromHashedName
+     */
     public function testUuid4WithoutOpensslRandomPseudoBytes()
     {
         Uuid::$forceNoOpensslRandomPseudoBytes = true;
+        $uuid = Uuid::uuid4();
+        $this->assertInstanceOf('Rhumsaa\Uuid\Uuid', $uuid);
+        $this->assertEquals(2, $uuid->getVariant());
+        $this->assertEquals(4, $uuid->getVersion());
+    }
+
+    /**
+     * @covers Rhumsaa\Uuid\Uuid::uuid4
+     * @covers Rhumsaa\Uuid\Uuid::generateBytes
+     * @covers Rhumsaa\Uuid\Uuid::uuidFromHashedName
+     */
+    public function testUuid4WithoutOpensslRandomPseudoBytesOrRandomNumberGenerator()
+    {
+        $this->skipIfNoRandomNumberGenerator();
+        Uuid::$forceNoOpensslRandomPseudoBytes = true;
+        Uuid::$forceNoRandomNumberGenerator = true;
         $uuid = Uuid::uuid4();
         $this->assertInstanceOf('Rhumsaa\Uuid\Uuid', $uuid);
         $this->assertEquals(2, $uuid->getVariant());


### PR DESCRIPTION
When openssl isn't available, `mt_rand` doesn't provide enought entropy, i.e. it is not a not cryptographically strong random number generator (as stated here http://php.net/manual/en/function.mt-rand.php).

The @ircmaxell random number generator (https://github.com/ircmaxell/RandomLib) always tend to provide better entropy by using multiple random sources, using it decreases drastically the risk of collision when we want to generate a large amount of random UUID.