### PR TITLE
[2.8] Remove rhumsaa from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "rhumsaa/uuid",
-    "description": "NO LONGER MAINTAINED. Use ramsey/uuid instead. A PHP 5.3+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+    "name": "ramsey/uuid",
+    "description": "A PHP 5.3+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
     "type": "library",
     "keywords": ["uuid", "identifier", "guid"],
-    "homepage": "https://github.com/ramsey/rhumsaa-uuid",
+    "homepage": "https://github.com/ramsey/uuid",
     "license": "MIT",
     "authors": [
         {
@@ -16,8 +16,8 @@
         }
     ],
     "support": {
-        "issues": "https://github.com/ramsey/rhumsaa-uuid/issues",
-        "source": "https://github.com/ramsey/rhumsaa-uuid"
+        "issues": "https://github.com/ramsey/uuid/issues",
+        "source": "https://github.com/ramsey/uuid"
     },
     "require": {
         "php": ">=5.3.3"


### PR DESCRIPTION
Just did a `composer show -i` and saw a big warning NO LONGER MAINTAINED on the ramsay/uuid package. This confused me because I was sure I switched months ago. I found out that there are still references to the old package inside the composer.json.