### PR TITLE
Test coverage providers

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,6 @@ if (!defined('HHVM_VERSION')) {
     $kernel = \AspectMock\Kernel::getInstance();
     $kernel->init([
         'debug' => true,
-        'includePaths' => [__DIR__ . '/../src/Generator']
+        'includePaths' => [__DIR__ . '/../src']
     ]);
 }

--- a/tests/src/Provider/Node/FallbackNodeProviderTest.php
+++ b/tests/src/Provider/Node/FallbackNodeProviderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Ramsey\Uuid\Test\Provider\Node;
+
+use Ramsey\Uuid\Provider\Node\FallbackNodeProvider;
+use Ramsey\Uuid\Test\TestCase;
+
+class FallbackNodeProviderTest extends TestCase
+{
+    public function testGetNodeCallsGetNodeOnEachProviderUntilNodeFound()
+    {
+        $providerWithNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithNode->expects($this->once())
+            ->method('getNode')
+            ->willReturn('57764a07f756');
+        $providerWithoutNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithoutNode->expects($this->once())
+            ->method('getNode')
+            ->willReturn(null);
+
+        $provider = new FallbackNodeProvider([$providerWithoutNode, $providerWithNode]);
+        $provider->getNode();
+    }
+
+    public function testGetNodeReturnsNodeFromFirstProviderWithNode()
+    {
+        $providerWithoutNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithoutNode->expects($this->once())
+            ->method('getNode')
+            ->willReturn(null);
+        $providerWithNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithNode->expects($this->once())
+            ->method('getNode')
+            ->willReturn('57764a07f756');
+        $anotherProviderWithoutNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $anotherProviderWithoutNode->expects($this->never())
+            ->method('getNode');
+
+        $provider = new FallbackNodeProvider([$providerWithoutNode, $providerWithNode, $anotherProviderWithoutNode]);
+        $node = $provider->getNode();
+        $this->assertEquals('57764a07f756', $node);
+    }
+
+    public function testGetNodeReturnsNullWhenNoNodesFound()
+    {
+        $providerWithoutNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithoutNode->method('getNode')
+            ->willReturn(null);
+
+        $provider = new FallbackNodeProvider([$providerWithoutNode]);
+        $node = $provider->getNode();
+        $this->assertNull($node);
+    }
+}

--- a/tests/src/Provider/Node/RandomNodeProviderTest.php
+++ b/tests/src/Provider/Node/RandomNodeProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Ramsey\Uuid\Test\Provider\Node;
+
+use Ramsey\Uuid\Provider\Node\RandomNodeProvider;
+use Ramsey\Uuid\Test\TestCase;
+use AspectMock\Test as AspectMock;
+
+class RandomNodeProviderTest extends TestCase
+{
+    private $num = 16532480;
+    private $node = 'fc4400fc4400';
+
+    public function setUp()
+    {
+        $this->skipIfHhvm();
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        AspectMock::clean();
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGetNodeUsesMtRand()
+    {
+        $mtRand = AspectMock::func('Ramsey\Uuid\Provider\Node', 'mt_rand', $this->num);
+        $provider = new RandomNodeProvider();
+        $provider->getNode();
+        $mtRand->verifyInvokedMultipleTimes(2, [0, 1 << 24]);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGetNodeFormatsRandomNumbersIntoHexString()
+    {
+        AspectMock::func('Ramsey\Uuid\Provider\Node', 'mt_rand', $this->num);
+        $sprintf = AspectMock::func('Ramsey\Uuid\Provider\Node', 'sprintf', $this->node);
+        $provider = new RandomNodeProvider();
+        $provider->getNode();
+        $sprintf->verifyInvoked(['%06x%06x', $this->num, $this->num]);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGetNodeReturnsHexString()
+    {
+        AspectMock::func('Ramsey\Uuid\Provider\Node', 'mt_rand', $this->num);
+        AspectMock::func('Ramsey\Uuid\Provider\Node', 'sprintf', $this->node);
+        $provider = new RandomNodeProvider();
+        $this->assertEquals($this->node, $provider->getNode());
+    }
+}

--- a/tests/src/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/src/Provider/Node/SystemNodeProviderTest.php
@@ -19,8 +19,8 @@ class SystemNodeProviderTest extends TestCase
 
         $this->assertTrue(ctype_xdigit($node), 'Node is not a hexadecimal string. Actual node: ' . $node);
         $this->assertTrue(strlen($node) === 12, 'Node is 12 characters long. Actual length: ' . strlen(
-                $node
-            ) . PHP_EOL . ' Actual node: ' . $node);
+            $node
+        ) . PHP_EOL . ' Actual node: ' . $node);
     }
 
 

--- a/tests/src/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/src/Provider/Node/SystemNodeProviderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Ramsey\Uuid\Test\Provider\Node;
+
+use Ramsey\Uuid\Provider\Node\SystemNodeProvider;
+use Ramsey\Uuid\Test\TestCase;
+use AspectMock\Test as AspectMock;
+
+class SystemNodeProviderTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGetNodeReturnsSystemNodeFromMacAddress()
+    {
+        $provider = new SystemNodeProvider();
+        $node = $provider->getNode();
+
+        $this->assertTrue(ctype_xdigit($node), 'Node is not a hexadecimal string. Actual node: ' . $node);
+        $this->assertTrue(strlen($node) === 12, 'Node is 12 characters long. Actual length: ' . strlen
+            ($node) . PHP_EOL . ' Actual node: ' . $node);
+    }
+
+
+    public function notationalFormatsDataProvider()
+    {
+        return [
+            ['01-23-45-67-89-ab', '0123456789ab'],
+            ['01:23:45:67:89:ab', '0123456789ab']
+        ];
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     * @dataProvider notationalFormatsDataProvider
+     * @param $formatted
+     * @param $expected
+     */
+    public function testGetNodeReturnsNodeStrippedOfNotationalFormatting($formatted, $expected)
+    {
+        //Stubbing a protected method so we can stub the results of getIfconfig
+        $provider = new class extends SystemNodeProvider
+        {
+            public $config;
+
+            protected function getIfconfig()
+            {
+                return $this->config;
+            }
+        };
+        $provider->config = PHP_EOL . $formatted . PHP_EOL;
+
+        $node = $provider->getNode();
+        $this->assertEquals($expected, $node);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGetNodeReturnsFirstMacAddressFound()
+    {
+        //Stubbing a protected method so we can stub having multiple addresses to match
+        $provider = new class extends SystemNodeProvider
+        {
+            public $config;
+
+            protected function getIfconfig()
+            {
+                return $this->config;
+            }
+        };
+        $provider->config = PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL .
+            '00-11-22-33-44-55' . PHP_EOL .
+            'FF-11-EE-22-DD-33' . PHP_EOL;
+
+        $node = $provider->getNode();
+        $this->assertEquals('AABBCCDDEEFF', $node);
+    }
+
+    public function osCommandDataProvider()
+    {
+        return [
+            'windows' => ['Windows', 'ipconfig /all 2>&1'],
+            'mac' => ['Darwhat', 'ifconfig 2>&1'],
+            'linux' => ['Linux', 'netstat -ie 2>&1'],
+            'anything_else' => ['someotherxyz', 'netstat -ie 2>&1']
+        ];
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     * @dataProvider osCommandDataProvider
+     * @param $os
+     * @param $command
+     */
+    public function testGetNodeGetsNetworkInterfaceConfig($os, $command)
+    {
+        AspectMock::func('Ramsey\Uuid\Provider\Node', 'php_uname', $os);
+        $passthru = AspectMock::func('Ramsey\Uuid\Provider\Node', 'passthru', 'whatever');
+
+        $provider = new SystemNodeProvider();
+        $provider->getNode();
+        $passthru->verifyInvokedOnce([$command]);
+    }
+
+}

--- a/tests/src/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/src/Provider/Node/SystemNodeProviderTest.php
@@ -40,17 +40,12 @@ class SystemNodeProviderTest extends TestCase
      */
     public function testGetNodeReturnsNodeStrippedOfNotationalFormatting($formatted, $expected)
     {
-        //Stubbing a protected method so we can stub the results of getIfconfig
-        $provider = new class extends SystemNodeProvider
-        {
-            public $config;
-
-            protected function getIfconfig()
-            {
-                return $this->config;
-            }
-        };
-        $provider->config = PHP_EOL . $formatted . PHP_EOL;
+        //Using a stub to provide data for the protected method that gets the node
+        $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
+            ->setMethods(['getIfconfig'])
+            ->getMock();
+        $provider->method('getIfconfig')
+            ->willReturn(PHP_EOL . $formatted . PHP_EOL);
 
         $node = $provider->getNode();
         $this->assertEquals($expected, $node);
@@ -62,19 +57,14 @@ class SystemNodeProviderTest extends TestCase
      */
     public function testGetNodeReturnsFirstMacAddressFound()
     {
-        //Stubbing a protected method so we can stub having multiple addresses to match
-        $provider = new class extends SystemNodeProvider
-        {
-            public $config;
-
-            protected function getIfconfig()
-            {
-                return $this->config;
-            }
-        };
-        $provider->config = PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL .
-            '00-11-22-33-44-55' . PHP_EOL .
-            'FF-11-EE-22-DD-33' . PHP_EOL;
+        //Using a stub to provide data for the protected method that gets the node
+        $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
+            ->setMethods(['getIfconfig'])
+            ->getMock();
+        $provider->method('getIfconfig')
+            ->willReturn(PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL .
+                '00-11-22-33-44-55' . PHP_EOL .
+                'FF-11-EE-22-DD-33' . PHP_EOL);
 
         $node = $provider->getNode();
         $this->assertEquals('AABBCCDDEEFF', $node);
@@ -113,14 +103,12 @@ class SystemNodeProviderTest extends TestCase
      */
     public function testGetNodeReturnsSameNodeUponSubsequentCalls()
     {
-        //Creating stub for the node
-        $provider = new class extends SystemNodeProvider
-        {
-            protected function getIfconfig()
-            {
-                return PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL;
-            }
-        };
+        //Using a stub to provide data for the protected method that gets the node
+        $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
+            ->setMethods(['getIfconfig'])
+            ->getMock();
+        $provider->method('getIfconfig')
+            ->willReturn(PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL);
 
         $node = $provider->getNode();
         $node2 = $provider->getNode();
@@ -133,25 +121,13 @@ class SystemNodeProviderTest extends TestCase
      */
     public function testSubsequentCallsToGetNodeDoNotRecallIfconfig()
     {
-        //Creating a mock so we can verify that the method is only called once.
-        $provider = new class extends SystemNodeProvider
-        {
-            private $calls = 0;
-
-            protected function getIfconfig()
-            {
-                $this->calls++;
-                return PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL;
-            }
-
-            public function __destruct()
-            {
-                if ($this->calls != 1) {
-                    throw new \Exception("getIfconfig was called {$this->calls} times, expected only once");
-                }
-            }
-        };
-
+        //Using a mock to verify the provider only gets the node from ifconfig one time
+        $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
+            ->setMethods(['getIfconfig'])
+            ->getMock();
+        $provider->expects($this->once())
+            ->method('getIfconfig')
+            ->willReturn(PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL);
         $provider->getNode();
         $provider->getNode();
     }

--- a/tests/src/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/src/Provider/Node/SystemNodeProviderTest.php
@@ -19,8 +19,8 @@ class SystemNodeProviderTest extends TestCase
 
         $this->assertTrue(ctype_xdigit($node), 'Node is not a hexadecimal string. Actual node: ' . $node);
         $this->assertTrue(strlen($node) === 12, 'Node is 12 characters long. Actual length: ' . strlen(
-            $node
-        ) . PHP_EOL . ' Actual node: ' . $node);
+                $node
+            ) . PHP_EOL . ' Actual node: ' . $node);
     }
 
 
@@ -90,6 +90,7 @@ class SystemNodeProviderTest extends TestCase
      */
     public function testGetNodeGetsNetworkInterfaceConfig($os, $command)
     {
+        $this->skipIfHhvm();
         AspectMock::func('Ramsey\Uuid\Provider\Node', 'php_uname', $os);
         $passthru = AspectMock::func('Ramsey\Uuid\Provider\Node', 'passthru', 'whatever');
 

--- a/tests/src/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/src/Provider/Node/SystemNodeProviderTest.php
@@ -17,10 +17,10 @@ class SystemNodeProviderTest extends TestCase
         $provider = new SystemNodeProvider();
         $node = $provider->getNode();
 
-        $this->assertTrue(ctype_xdigit($node), 'Node is not a hexadecimal string. Actual node: ' . $node);
-        $this->assertTrue(strlen($node) === 12, 'Node is 12 characters long. Actual length: ' . strlen(
-            $node
-        ) . PHP_EOL . ' Actual node: ' . $node);
+        $this->assertTrue(ctype_xdigit($node), 'Node should be a hexadecimal string. Actual node: ' . $node);
+        $length = strlen($node);
+        $lengthError = 'Node should be 12 characters. Actual length: ' . $length . PHP_EOL . ' Actual node: ' . $node;
+        $this->assertTrue(($length === 12), $lengthError);
     }
 
 

--- a/tests/src/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/src/Provider/Node/SystemNodeProviderTest.php
@@ -18,8 +18,9 @@ class SystemNodeProviderTest extends TestCase
         $node = $provider->getNode();
 
         $this->assertTrue(ctype_xdigit($node), 'Node is not a hexadecimal string. Actual node: ' . $node);
-        $this->assertTrue(strlen($node) === 12, 'Node is 12 characters long. Actual length: ' . strlen
-            ($node) . PHP_EOL . ' Actual node: ' . $node);
+        $this->assertTrue(strlen($node) === 12, 'Node is 12 characters long. Actual length: ' . strlen(
+            $node
+        ) . PHP_EOL . ' Actual node: ' . $node);
     }
 
 
@@ -131,5 +132,4 @@ class SystemNodeProviderTest extends TestCase
         $provider->getNode();
         $provider->getNode();
     }
-
 }

--- a/tests/src/Provider/Time/FixedTimeProviderTest.php
+++ b/tests/src/Provider/Time/FixedTimeProviderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ramsey\Uuid\Test\Provider\Time;
+
+use Ramsey\Uuid\Provider\Time\FixedTimeProvider;
+use Ramsey\Uuid\Test\TestCase;
+
+class FixedTimeProviderTest extends TestCase
+{
+
+    public function testConstructorRequiresSecAndUsec()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $provider = new FixedTimeProvider([]);
+    }
+
+    public function testCurrentTimeReturnsTimestamp()
+    {
+        $timestamp = ['sec' => 1458844556, 'usec' => 200997];
+        $provider = new FixedTimeProvider($timestamp);
+        $this->assertEquals($timestamp, $provider->currentTime());
+    }
+
+    public function testCurrentTimeReturnsTimestampAfterChange()
+    {
+        $timestamp = ['sec' => 1458844556, 'usec' => 200997];
+        $provider = new FixedTimeProvider($timestamp);
+
+        $newTimestamp = ['sec' => 1050804050, 'usec' => '30192'];
+        $provider->setSec($newTimestamp['sec']);
+        $provider->setUsec($newTimestamp['usec']);
+
+        $this->assertEquals($newTimestamp, $provider->currentTime());
+    }
+}

--- a/tests/src/Provider/Time/SystemTimeProviderTest.php
+++ b/tests/src/Provider/Time/SystemTimeProviderTest.php
@@ -31,5 +31,4 @@ class SystemTimeProviderTest extends TestCase
         $func->verifyInvokedOnce();
 
     }
-
 }

--- a/tests/src/Provider/Time/SystemTimeProviderTest.php
+++ b/tests/src/Provider/Time/SystemTimeProviderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ramsey\Uuid\Test\Provider\Time;
+
+use Ramsey\Uuid\Provider\Time\SystemTimeProvider;
+use Ramsey\Uuid\Test\TestCase;
+use AspectMock\Test as AspectMock;
+
+class SystemTimeProviderTest extends TestCase
+{
+
+    public function testCurrentTimeReturnsTimestampArray()
+    {
+        $provider = new SystemTimeProvider();
+        $time = $provider->currentTime();
+        $this->assertArrayHasKey('sec', $time);
+        $this->assertArrayHasKey('usec', $time);
+    }
+
+    public function testCurrentTimeUsesGettimeofday()
+    {
+        $this->skipIfHhvm();
+        $time = ['sec' => 1458844556, 'usec' => 200997];
+        $func = AspectMock::func('Ramsey\Uuid\Provider\Time', 'gettimeofday', $time);
+        $provider = new SystemTimeProvider();
+        $this->assertEquals($time, $provider->currentTime());
+        $func->verifyInvokedOnce();
+
+    }
+
+}

--- a/tests/src/Provider/Time/SystemTimeProviderTest.php
+++ b/tests/src/Provider/Time/SystemTimeProviderTest.php
@@ -17,13 +17,17 @@ class SystemTimeProviderTest extends TestCase
         $this->assertArrayHasKey('usec', $time);
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testCurrentTimeUsesGettimeofday()
     {
         $this->skipIfHhvm();
-        $time = ['sec' => 1458844556, 'usec' => 200997];
-        $func = AspectMock::func('Ramsey\Uuid\Provider\Time', 'gettimeofday', $time);
+        $timestamp = ['sec' => 1458844556, 'usec' => 200997];
+        $func = AspectMock::func('Ramsey\Uuid\Provider\Time', 'gettimeofday', $timestamp);
         $provider = new SystemTimeProvider();
-        $this->assertEquals($time, $provider->currentTime());
+        $provider->currentTime();
         $func->verifyInvokedOnce();
 
     }

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -1,8 +1,18 @@
 <?php
 namespace Ramsey\Uuid\Test;
 
+use AspectMock\Test as AspectMock;
+
 class TestCase extends \PHPUnit_Framework_TestCase
 {
+    public function tearDown()
+    {
+        parent::tearDown();
+        if (!self::isHhvm()) {
+            AspectMock::clean();
+        }
+    }
+
     protected function skip64BitTest()
     {
         if (PHP_INT_SIZE == 4) {


### PR DESCRIPTION
- Added tests for all Providers. All tests are isolated correctness/contract/collaboration tests. 
- Moved the AspectMock teardown into the TestCase teardown. This won't affect anything that isn't using AspectMock, and will prevent forgetting to clean AspectMock when a test is over. 