### PR TITLE
Codec to store UUID in an optimized way for InnoDB

### DIFF
--- a/src/Codec/OrderedTimeCodec.php
+++ b/src/Codec/OrderedTimeCodec.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of the ramsey/uuid library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link https://benramsey.com/projects/ramsey-uuid/ Documentation
+ * @link https://packagist.org/packages/ramsey/uuid Packagist
+ * @link https://github.com/ramsey/uuid GitHub
+ */
+namespace Ramsey\Uuid\Codec;
+
+use InvalidArgumentException;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * OrderedTimeCodec optimizes the bytes to increment UUIDs when time goes by, to improve database INSERTs.
+ * The string value will be unchanged from StringCodec. Only works for UUID type 1.
+ */
+class OrderedTimeCodec extends StringCodec
+{
+
+    /**
+     * Encodes a UuidInterface as an optimized binary representation of a UUID
+     *
+     * @param UuidInterface $uuid
+     * @return string Binary string representation of a UUID
+     */
+    public function encodeBinary(UuidInterface $uuid)
+    {
+        $fields = $uuid->getFieldsHex();
+
+        $optimized = [
+            $fields['time_hi_and_version'],
+            $fields['time_mid'],
+            $fields['time_low'],
+            $fields['clock_seq_hi_and_reserved'],
+            $fields['clock_seq_low'],
+            $fields['node'],
+        ];
+
+        return hex2bin(implode('', $optimized));
+    }
+
+    /**
+     * Decodes an optimized binary representation of a UUID into a UuidInterface object instance
+     *
+     * @param string $bytes
+     * @return UuidInterface
+     */
+    public function decodeBytes($bytes)
+    {
+        if (strlen($bytes) !== 16) {
+            throw new InvalidArgumentException('$bytes string should contain 16 characters.');
+        }
+
+        $hex = unpack('H*', $bytes)[1];
+
+        // Rearrange the fields to their original order
+        $hex = substr($hex, 8, 4) . substr($hex, 12, 4) . substr($hex, 4, 4) . substr($hex, 0, 4) . substr($hex, 16);
+
+        return $this->decode($hex);
+    }
+}

--- a/tests/src/Codec/OrderedTimeCodecTest.php
+++ b/tests/src/Codec/OrderedTimeCodecTest.php
@@ -84,6 +84,15 @@ class OrderedTimeCodecTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testDecodeBytesThrowsExceptionWhenBytesStringNotSixteenCharacters()
+    {
+        $string = '61';
+        $bytes = pack('H*', $string);
+        $codec = new OrderedTimeCodec($this->builder);
+        $this->setExpectedException('InvalidArgumentException', '$bytes string should contain 16 characters.');
+        $codec->decodeBytes($bytes);
+    }
+
     public function testDecodeReturnsUuidFromBuilder()
     {
         $string = 'uuid:58e0a7d7-eebc-11d8-9669-0800200c9a66';

--- a/tests/src/Codec/OrderedTimeCodecTest.php
+++ b/tests/src/Codec/OrderedTimeCodecTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Ramsey\Uuid\Test\Codec;
+
+use Ramsey\Uuid\Builder\UuidBuilderInterface;
+use Ramsey\Uuid\Codec\OrderedTimeCodec;
+use Ramsey\Uuid\Test\TestCase;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * Class OrderedTimeCodecTest
+ * @package Ramsey\Uuid\Test\Codec
+ * @covers Ramsey\Uuid\Codec\OrderedTimeCodec
+ */
+class OrderedTimeCodecTest extends TestCase
+{
+
+    /** @var UuidBuilderInterface */
+    private $builder;
+    /** @var UuidInterface */
+    private $uuid;
+    /** @var array */
+    private $fields;
+    /** @var string */
+    private $uuidString = '58e0a7d7-eebc-11d8-9669-0800200c9a66';
+    /** @var string */
+    private $optimizedHex = '11d8eebc58e0a7d796690800200c9a66';
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->builder = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
+        $this->uuid = $this->getMock('Ramsey\Uuid\UuidInterface');
+        $this->fields = ['time_low' => '58e0a7d7',
+            'time_mid' => 'eebc',
+            'time_hi_and_version' => '11d8',
+            'clock_seq_hi_and_reserved' => '96',
+            'clock_seq_low' => '69',
+            'node' => '0800200c9a66'];
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->builder = null;
+        $this->uuid = null;
+        $this->fields = null;
+    }
+
+    public function testEncodeUsesFieldsArray()
+    {
+        $this->uuid->expects($this->once())
+            ->method('getFieldsHex')
+            ->willReturn($this->fields);
+        $codec = new OrderedTimeCodec($this->builder);
+        $codec->encode($this->uuid);
+    }
+
+    public function testEncodeReturnsFormattedString()
+    {
+        $this->uuid->method('getFieldsHex')
+            ->willReturn($this->fields);
+        $codec = new OrderedTimeCodec($this->builder);
+        $result = $codec->encode($this->uuid);
+        $this->assertEquals($this->uuidString, $result);
+    }
+
+    public function testEncodeBinaryUsesFieldsHex()
+    {
+        $this->uuid->expects($this->once())
+            ->method('getFieldsHex')
+            ->willReturn($this->fields);
+        $codec = new OrderedTimeCodec($this->builder);
+        $codec->encodeBinary($this->uuid);
+    }
+
+    public function testEncodeBinaryReturnsBinaryString()
+    {
+        $expected = hex2bin($this->optimizedHex);
+        $this->uuid->method('getFieldsHex')
+            ->willReturn($this->fields);
+        $codec = new OrderedTimeCodec($this->builder);
+        $result = $codec->encodeBinary($this->uuid);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testDecodeReturnsUuidFromBuilder()
+    {
+        $string = 'uuid:58e0a7d7-eebc-11d8-9669-0800200c9a66';
+        $this->builder->method('build')
+            ->willReturn($this->uuid);
+        $codec = new OrderedTimeCodec($this->builder);
+        $result = $codec->decode($string);
+        $this->assertEquals($this->uuid, $result);
+    }
+
+    public function testDecodeBytesRearrangesFields()
+    {
+        $bytes = pack('H*', $this->optimizedHex);
+        $codec = new OrderedTimeCodec($this->builder);
+        $this->builder->method('build')->with($this->anything(), $this->equalTo($this->fields))
+            ->willReturn($this->uuid);
+        $result = $codec->decodeBytes($bytes);
+        $this->assertEquals($this->uuid, $result);
+    }
+}


### PR DESCRIPTION
Fixes #117: Store UUID in an optimized way for InnoDB

Adds a Coded that extends the StringCodec. The string encoding is unchanged, but the binary output is rearranged so that it increases over time (instead of random). The UUID fields itself have not change, only the ordering. No data is lost, so decoding back will give the original string.

Example use case would be to store the data in an optimized way, but show the original UUID in the admin interface. See below for examples, if you run it, you'll see that you can convert the UUID back and forth + the binary values are increasing, as suggested by https://www.percona.com/blog/2014/12/19/store-uuid-optimized-way/

The tests should cover this also.

Example usage:

```php
use Ramsey\Uuid\Uuid;
use Ramsey\Uuid\Codec\OrderedTimeCodec;
use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;

// Generate a version 1 (time-based) UUID object
$uuid1 = Uuid::uuid1();
echo $uuid1->toString() . "\n"; // i.e. 58e0a7d7-eebc-11d8-9669-0800200c9a66
echo bin2hex($uuid1->getBytes()) . "\n"; // i.e. 58e0a7d7eebc11d896690800200c9a66

// Generate an optimized version 1 (time-based) UUID object
$factory = new \Ramsey\Uuid\UuidFactory();
$codec = new OrderedTimeCodec($factory->getUuidBuilder());
$factory->setCodec($codec);
Uuid::setFactory($factory);

$uuid1 = Uuid::uuid1();
echo $uuid1->toString() . "\n"; // i.e. 58e0a7d7-eebc-11d8-9669-0800200c9a66
$optimized = $uuid1->getBytes();
echo bin2hex($optimized) . "\n"; // i.e. 11d8eebc58e0a7d796690800200c9a66
echo Uuid::fromBytes($optimized)->toString() . "\n"; // i.e. 58e0a7d7-eebc-11d8-9669-0800200c9a66

// Generate multiple uuid in incrementing order
for ($i=0;$i < 10; $i++) {
    echo bin2hex(Uuid::uuid1()->getBytes()) . "\n";
}
```

Example output:
```
379ed1f8-0cac-11e6-bf97-bc5ff48511f3
379ed1f80cac11e6bf97bc5ff48511f3

379ee378-0cac-11e6-a807-bc5ff48511f3
11e60cac379ee378a807bc5ff48511f3
379ee378-0cac-11e6-a807-bc5ff48511f3

11e60cac379ee6c0a991bc5ff48511f3
11e60cac379ee7c4afe6bc5ff48511f3
11e60cac379ee8aabc1abc5ff48511f3
...
```