### PR TITLE
Fix RandomNodeProvider: change the max value in mt_rand() call to prevent invalid node generation

### DIFF
--- a/src/Provider/Node/RandomNodeProvider.php
+++ b/src/Provider/Node/RandomNodeProvider.php
@@ -31,6 +31,6 @@ class RandomNodeProvider implements NodeProviderInterface
      */
     public function getNode()
     {
-        return sprintf('%06x%06x', mt_rand(0, 1 << 24), mt_rand(0, 1 << 24));
+        return sprintf('%06x%06x', mt_rand(0, 0xffffff), mt_rand(0, 0xffffff));
     }
 }

--- a/tests/src/Provider/Node/RandomNodeProviderTest.php
+++ b/tests/src/Provider/Node/RandomNodeProviderTest.php
@@ -32,7 +32,7 @@ class RandomNodeProviderTest extends TestCase
         $mtRand = AspectMock::func('Ramsey\Uuid\Provider\Node', 'mt_rand', $this->num);
         $provider = new RandomNodeProvider();
         $provider->getNode();
-        $mtRand->verifyInvokedMultipleTimes(2, [0, 1 << 24]);
+        $mtRand->verifyInvokedMultipleTimes(2, [0, 0xffffff]);
     }
 
     /**

--- a/tests/src/Provider/Time/SystemTimeProviderTest.php
+++ b/tests/src/Provider/Time/SystemTimeProviderTest.php
@@ -29,6 +29,5 @@ class SystemTimeProviderTest extends TestCase
         $provider = new SystemTimeProvider();
         $provider->currentTime();
         $func->verifyInvokedOnce();
-
     }
 }


### PR DESCRIPTION
When at least one call of `mt_rand(0, 1 << 24)` in  `RandomNodeProvider::getNode()` returns `1 << 24 // 0x1000000` the method generates a hexadecimal string that contain one digit more than needed to be correct. As a result, exception 'Invalid node value' is thrown when we trying to generate UUIDv1 with `DefaultTimeGenerator`. I faced with it in practice.

Therefore, i suggest to use `0xffffff` instead of `1 << 24` to fix this behaviour.