### PR TITLE
Fixed undefined classes in GuidStringCodecTest properties

### DIFF
--- a/tests/src/Codec/GuidStringCodecTest.php
+++ b/tests/src/Codec/GuidStringCodecTest.php
@@ -2,8 +2,10 @@
 
 namespace Ramsey\Uuid\Test\Codec;
 
+use Ramsey\Uuid\Builder\UuidBuilderInterface;
 use Ramsey\Uuid\Codec\GuidStringCodec;
 use Ramsey\Uuid\Test\TestCase;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Class GuidStringCodecTest


### PR DESCRIPTION
I found out these two phpDocs pointed to undefined classes. I added them as use statements.

BTW: I found this issue using my new static analysis tool [PHPStan](https://github.com/phpstan/phpstan). I can send you a PR with integrating the tool in the package's build script if you're interested :)