### PR TITLE
Fix: Reduce visibility of setUp() and tearDown()

### DIFF
--- a/tests/src/Codec/GuidStringCodecTest.php
+++ b/tests/src/Codec/GuidStringCodecTest.php
@@ -22,7 +22,7 @@ class GuidStringCodecTest extends TestCase
     /** @var array */
     private $fields;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->builder = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
@@ -35,7 +35,7 @@ class GuidStringCodecTest extends TestCase
             'node' => '1234abcd4321'];
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         $this->builder = null;

--- a/tests/src/Codec/OrderedTimeCodecTest.php
+++ b/tests/src/Codec/OrderedTimeCodecTest.php
@@ -26,7 +26,7 @@ class OrderedTimeCodecTest extends TestCase
     /** @var string */
     private $optimizedHex = '11d8eebc58e0a7d796690800200c9a66';
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->builder = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
@@ -39,7 +39,7 @@ class OrderedTimeCodecTest extends TestCase
             'node' => '0800200c9a66'];
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         $this->builder = null;

--- a/tests/src/Codec/StringCodecTest.php
+++ b/tests/src/Codec/StringCodecTest.php
@@ -24,7 +24,7 @@ class StringCodecTest extends TestCase
     /** @var string */
     private $uuidString = '12345678-1234-abcd-abef-1234abcd4321';
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->builder = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
@@ -37,7 +37,7 @@ class StringCodecTest extends TestCase
             'node' => '1234abcd4321'];
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         $this->builder = null;

--- a/tests/src/Encoder/TimestampFirstCombCodecTest.php
+++ b/tests/src/Encoder/TimestampFirstCombCodecTest.php
@@ -18,7 +18,7 @@ class TimestampFirstCombCodecTest extends TestCase
      */
     private $builderMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->builderMock = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
         $this->codec = new TimestampFirstCombCodec($this->builderMock);

--- a/tests/src/Encoder/TimestampLastCombCodecTest.php
+++ b/tests/src/Encoder/TimestampLastCombCodecTest.php
@@ -18,7 +18,7 @@ class TimestampLastCombCodecTest extends TestCase
      */
     private $builderMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->builderMock = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
         $this->codec = new TimestampLastCombCodec($this->builderMock);

--- a/tests/src/Generator/DefaultTimeGeneratorTest.php
+++ b/tests/src/Generator/DefaultTimeGeneratorTest.php
@@ -28,7 +28,7 @@ class DefaultTimeGeneratorTest extends TestCase
     private $clockSeq = 4066;
 
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->timeProvider = $this->getMock('Ramsey\Uuid\Provider\TimeProviderInterface');
@@ -38,7 +38,7 @@ class DefaultTimeGeneratorTest extends TestCase
         $this->calculatedTime = ["low" => "83cb98e0", "mid" => "98e0", "hi" => "03cb"];
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         $this->timeProvider = null;

--- a/tests/src/Generator/OpenSslGeneratorTest.php
+++ b/tests/src/Generator/OpenSslGeneratorTest.php
@@ -13,7 +13,7 @@ use AspectMock\Test as AspectMock;
  */
 class OpenSslGeneratorTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->skipIfHhvm();
         parent::setUp();

--- a/tests/src/Generator/PeclUuidTestCase.php
+++ b/tests/src/Generator/PeclUuidTestCase.php
@@ -16,7 +16,7 @@ class PeclUuidTestCase extends TestCase
     protected $uuidString = 'b08c6fff-7dc5-e111-9b21-0800200c9a66';
     protected $uuidBinary = '62303863366666662d376463352d653131312d396232312d303830303230306339613636';
 
-    public function setUp()
+    protected function setUp()
     {
         $this->skipIfHhvm();
         parent::setUp();

--- a/tests/src/Generator/RandomBytesGeneratorTest.php
+++ b/tests/src/Generator/RandomBytesGeneratorTest.php
@@ -13,7 +13,7 @@ use AspectMock\Test as AspectMock;
  */
 class RandomBytesGeneratorTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->skipIfHhvm();
         parent::setUp();

--- a/tests/src/Generator/SodiumRandomGeneratorTest.php
+++ b/tests/src/Generator/SodiumRandomGeneratorTest.php
@@ -7,7 +7,7 @@ use Ramsey\Uuid\Generator\SodiumRandomGenerator;
 
 class SodiumRandomGeneratorTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!extension_loaded('libsodium')) {
             $this->markTestSkipped(

--- a/tests/src/Provider/Node/RandomNodeProviderTest.php
+++ b/tests/src/Provider/Node/RandomNodeProviderTest.php
@@ -11,13 +11,13 @@ class RandomNodeProviderTest extends TestCase
     private $num = 16532480;
     private $node = 'fc4400fc4400';
 
-    public function setUp()
+    protected function setUp()
     {
         $this->skipIfHhvm();
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         AspectMock::clean();

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -6,7 +6,7 @@ use Mockery;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         if (!self::isHhvm()) {


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `seUp()` and `tearDown()` from `public` to `protected`

💁 This is the visibility as declared on the parent; there's no need to increase it.