### PR TITLE
Fix: Move operations to appropriate sections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,16 @@ php:
 
 sudo: false
 
-before_script:
+before_install:
   - travis_retry composer self-update
+
+install:
   - travis_retry composer install --no-interaction --prefer-dist
 
-script:
+before_script:
   - mkdir -p build/logs
+
+script:
   - ./vendor/bin/parallel-lint src tests
   - ./vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml
   - ./vendor/bin/phpcs src tests --standard=psr2 -sp


### PR DESCRIPTION
This PR

* [x] moves operations to be executed on Travis to the appropriate sections in `.travis.yml`

💁 For reference, see https://docs.travis-ci.com/user/customizing-the-build#The-Build-Lifecycle.