### PR TITLE
UUID equals case-insensitive

### DIFF
--- a/src/UuidFactory.php
+++ b/src/UuidFactory.php
@@ -187,6 +187,7 @@ class UuidFactory implements UuidFactoryInterface
 
     public function fromString($uuid)
     {
+        $uuid = strtolower($uuid);
         return $this->codec->decode($uuid);
     }
 

--- a/tests/UuidFactoryTest.php
+++ b/tests/UuidFactoryTest.php
@@ -24,4 +24,15 @@ class UuidFactoryTest extends TestCase
 
         $this->assertEquals('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
     }
+
+    public function testFromStringParsesUuidInLowercase()
+    {
+        $uuidString = 'ff6f8cb0-c57d-11e1-9b21-0800200c9a66';
+        $uuidUpper = strtoupper($uuidString);
+        $factory = new UuidFactory(new FeatureSet(true));
+
+        $uuid = $factory->fromString($uuidUpper);
+
+        $this->assertEquals($uuidString, $uuid->toString());
+    }
 }

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -790,7 +790,7 @@ class UuidTest extends TestCase
             $this->assertEquals(Uuid::RFC_4122, $uobj->getVariant());
             $this->assertEquals(3, $uobj->getVersion());
             $this->assertEquals(Uuid::fromString($ustr), $uobj);
-            $this->assertEquals((string) $uobj, $ustr);
+            $this->assertEquals((string)$uobj, $ustr);
         }
     }
 
@@ -815,7 +815,7 @@ class UuidTest extends TestCase
             ->method('generate')
             ->willReturnCallback(function ($length) {
 
-            // Makes first fields of UUIDs equal
+                // Makes first fields of UUIDs equal
                 return str_pad('', $length, '0');
             });
 
@@ -827,7 +827,7 @@ class UuidTest extends TestCase
 
         $previous = $factory->uuid4();
 
-        for ($i = 0; $i < 1000; $i ++) {
+        for ($i = 0; $i < 1000; $i++) {
             usleep(10);
             $uuid = $factory->uuid4();
             $this->assertGreaterThan($previous->toString(), $uuid->toString());
@@ -859,7 +859,7 @@ class UuidTest extends TestCase
 
         $previous = $factory->uuid4();
 
-        for ($i = 0; $i < 1000; $i ++) {
+        for ($i = 0; $i < 1000; $i++) {
             usleep(10);
             $uuid = $factory->uuid4();
             $this->assertGreaterThan($previous->toString(), $uuid->toString());
@@ -935,7 +935,7 @@ class UuidTest extends TestCase
             $this->assertEquals(Uuid::RFC_4122, $uobj->getVariant());
             $this->assertEquals(5, $uobj->getVersion());
             $this->assertEquals(Uuid::fromString($ustr), $uobj);
-            $this->assertEquals((string) $uobj, $ustr);
+            $this->assertEquals((string)$uobj, $ustr);
         }
     }
 
@@ -965,6 +965,28 @@ class UuidTest extends TestCase
         $this->assertEquals(1, $uuid4->compareTo($uuid3));
         $this->assertEquals(-1, $uuid5->compareTo($uuid3));
         $this->assertEquals(1, $uuid3->compareto($uuid5));
+    }
+
+    public function testCompareToReturnsZeroWhenDifferentCases()
+    {
+        $uuidString = 'ff6f8cb0-c57d-11e1-9b21-0800200c9a66';
+        // $uuid1 and $uuid2 are identical
+        $uuid1 = Uuid::fromString($uuidString);
+        $uuid2 = Uuid::fromString(strtoupper($uuidString));
+
+        $this->assertEquals(0, $uuid1->compareTo($uuid2));
+        $this->assertEquals(0, $uuid2->compareTo($uuid1));
+    }
+
+    public function testEqualsReturnsTrueWhenDifferentCases()
+    {
+        $uuidString = 'ff6f8cb0-c57d-11e1-9b21-0800200c9a66';
+        // $uuid1 and $uuid2 are identical
+        $uuid1 = Uuid::fromString($uuidString);
+        $uuid2 = Uuid::fromString(strtoupper($uuidString));
+
+        $this->assertTrue($uuid1->equals($uuid2));
+        $this->assertTrue($uuid2->equals($uuid1));
     }
 
     /**
@@ -999,7 +1021,7 @@ class UuidTest extends TestCase
         Uuid::setFactory(new UuidFactory($featureSet));
         $uuidA = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('c4dbe7e2-097f-11e2-9669-00007ffffffe', (string) $uuidA);
+        $this->assertEquals('c4dbe7e2-097f-11e2-9669-00007ffffffe', (string)$uuidA);
         $this->assertEquals('c4dbe7e2', $uuidA->getTimeLowHex());
         $this->assertEquals('097f', $uuidA->getTimeMidHex());
         $this->assertEquals('11e2', $uuidA->getTimeHiAndVersionHex());
@@ -1008,7 +1030,7 @@ class UuidTest extends TestCase
         $timeOfDay->setUsec(0);
         $uuidB = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('c4b18100-097f-11e2-9669-00007ffffffe', (string) $uuidB);
+        $this->assertEquals('c4b18100-097f-11e2-9669-00007ffffffe', (string)$uuidB);
         $this->assertEquals('c4b18100', $uuidB->getTimeLowHex());
         $this->assertEquals('097f', $uuidB->getTimeMidHex());
         $this->assertEquals('11e2', $uuidB->getTimeHiAndVersionHex());
@@ -1017,7 +1039,7 @@ class UuidTest extends TestCase
         $timeOfDay->setUsec(999999);
         $uuidC = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('c54a1776-097f-11e2-9669-00007ffffffe', (string) $uuidC);
+        $this->assertEquals('c54a1776-097f-11e2-9669-00007ffffffe', (string)$uuidC);
         $this->assertEquals('c54a1776', $uuidC->getTimeLowHex());
         $this->assertEquals('097f', $uuidC->getTimeMidHex());
         $this->assertEquals('11e2', $uuidC->getTimeHiAndVersionHex());
@@ -1044,7 +1066,7 @@ class UuidTest extends TestCase
         // For usec = 277885
         $uuidA = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('c4dbe7e2-097f-11e2-9669-00007ffffffe', (string) $uuidA);
+        $this->assertEquals('c4dbe7e2-097f-11e2-9669-00007ffffffe', (string)$uuidA);
         $this->assertEquals('c4dbe7e2', $uuidA->getTimeLowHex());
         $this->assertEquals('097f', $uuidA->getTimeMidHex());
         $this->assertEquals('11e2', $uuidA->getTimeHiAndVersionHex());
@@ -1053,7 +1075,7 @@ class UuidTest extends TestCase
         $timeOfDay->setUsec(0);
         $uuidB = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('c4b18100-097f-11e2-9669-00007ffffffe', (string) $uuidB);
+        $this->assertEquals('c4b18100-097f-11e2-9669-00007ffffffe', (string)$uuidB);
         $this->assertEquals('c4b18100', $uuidB->getTimeLowHex());
         $this->assertEquals('097f', $uuidB->getTimeMidHex());
         $this->assertEquals('11e2', $uuidB->getTimeHiAndVersionHex());
@@ -1062,7 +1084,7 @@ class UuidTest extends TestCase
         $timeOfDay->setUsec(999999);
         $uuidC = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('c54a1776-097f-11e2-9669-00007ffffffe', (string) $uuidC);
+        $this->assertEquals('c54a1776-097f-11e2-9669-00007ffffffe', (string)$uuidC);
         $this->assertEquals('c54a1776', $uuidC->getTimeLowHex());
         $this->assertEquals('097f', $uuidC->getTimeMidHex());
         $this->assertEquals('11e2', $uuidC->getTimeHiAndVersionHex());
@@ -1088,7 +1110,7 @@ class UuidTest extends TestCase
         Uuid::setFactory(new UuidFactory($featureSet));
         $uuidA = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('ff9785f6-ffff-1fff-9669-00007ffffffe', (string) $uuidA);
+        $this->assertEquals('ff9785f6-ffff-1fff-9669-00007ffffffe', (string)$uuidA);
         $this->assertEquals('ff9785f6', $uuidA->getTimeLowHex());
         $this->assertEquals('ffff', $uuidA->getTimeMidHex());
         $this->assertEquals('1fff', $uuidA->getTimeHiAndVersionHex());
@@ -1106,7 +1128,7 @@ class UuidTest extends TestCase
         Uuid::setFactory(new UuidFactory($featureSet));
         $uuidB = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('00000000-0000-1000-9669-00007ffffffe', (string) $uuidB);
+        $this->assertEquals('00000000-0000-1000-9669-00007ffffffe', (string)$uuidB);
         $this->assertEquals('00000000', $uuidB->getTimeLowHex());
         $this->assertEquals('0000', $uuidB->getTimeMidHex());
         $this->assertEquals('1000', $uuidB->getTimeHiAndVersionHex());
@@ -1138,7 +1160,7 @@ class UuidTest extends TestCase
 
         $uuidA = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('ff9785f6-ffff-1fff-9669-00007ffffffe', (string) $uuidA);
+        $this->assertEquals('ff9785f6-ffff-1fff-9669-00007ffffffe', (string)$uuidA);
         $this->assertEquals('ff9785f6', $uuidA->getTimeLowHex());
         $this->assertEquals('ffff', $uuidA->getTimeMidHex());
         $this->assertEquals('1fff', $uuidA->getTimeHiAndVersionHex());
@@ -1157,7 +1179,7 @@ class UuidTest extends TestCase
 
         $uuidB = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('00000000-0000-1000-9669-00007ffffffe', (string) $uuidB);
+        $this->assertEquals('00000000-0000-1000-9669-00007ffffffe', (string)$uuidB);
         $this->assertEquals('00000000', $uuidB->getTimeLowHex());
         $this->assertEquals('0000', $uuidB->getTimeMidHex());
         $this->assertEquals('1000', $uuidB->getTimeHiAndVersionHex());
@@ -1184,7 +1206,7 @@ class UuidTest extends TestCase
 
         $uuidA = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('13813ff6-6912-11fe-9669-00007ffffffe', (string) $uuidA);
+        $this->assertEquals('13813ff6-6912-11fe-9669-00007ffffffe', (string)$uuidA);
         $this->assertEquals('13813ff6', $uuidA->getTimeLowHex());
         $this->assertEquals('6912', $uuidA->getTimeMidHex());
         $this->assertEquals('11fe', $uuidA->getTimeHiAndVersionHex());
@@ -1203,7 +1225,7 @@ class UuidTest extends TestCase
 
         $uuidB = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('1419d680-d292-1165-9669-00007ffffffe', (string) $uuidB);
+        $this->assertEquals('1419d680-d292-1165-9669-00007ffffffe', (string)$uuidB);
         $this->assertEquals('1419d680', $uuidB->getTimeLowHex());
         $this->assertEquals('d292', $uuidB->getTimeMidHex());
         $this->assertEquals('1165', $uuidB->getTimeHiAndVersionHex());
@@ -1233,7 +1255,7 @@ class UuidTest extends TestCase
 
         $uuidA = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('13813ff6-6912-11fe-9669-00007ffffffe', (string) $uuidA);
+        $this->assertEquals('13813ff6-6912-11fe-9669-00007ffffffe', (string)$uuidA);
         $this->assertEquals('13813ff6', $uuidA->getTimeLowHex());
         $this->assertEquals('6912', $uuidA->getTimeMidHex());
         $this->assertEquals('11fe', $uuidA->getTimeHiAndVersionHex());
@@ -1248,11 +1270,10 @@ class UuidTest extends TestCase
 
         $featureSet->setTimeProvider($timeOfDay);
 
-        Uuid::setFactory(new UuidFactory($featureSet));
-        ;
+        Uuid::setFactory(new UuidFactory($featureSet));;
         $uuidB = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertEquals('1419d680-d292-1165-9669-00007ffffffe', (string) $uuidB);
+        $this->assertEquals('1419d680-d292-1165-9669-00007ffffffe', (string)$uuidB);
         $this->assertEquals('1419d680', $uuidB->getTimeLowHex());
         $this->assertEquals('d292', $uuidB->getTimeMidHex());
         $this->assertEquals('1165', $uuidB->getTimeHiAndVersionHex());
@@ -1298,7 +1319,7 @@ class UuidTest extends TestCase
                 $this->assertTrue(
                     $uuid32->equals($uuid64),
                     'Breaks at ' . gmdate('r', $currentTime)
-                        . "; 32-bit: {$uuid32->toString()}, 64-bit: {$uuid64->toString()}"
+                    . "; 32-bit: {$uuid32->toString()}, 64-bit: {$uuid64->toString()}"
                 );
 
                 // Assert that the time matches
@@ -1821,11 +1842,11 @@ class UuidTest extends TestCase
                 Uuid::fromInteger($test['int']),
             );
             foreach ($uuids as $uuid) {
-                $this->assertEquals($test['string'], (string) $uuid);
+                $this->assertEquals($test['string'], (string)$uuid);
                 $this->assertEquals($test['hex'], $uuid->getHex());
                 $this->assertEquals(base64_decode($test['bytes']), $uuid->getBytes());
                 if ($this->hasMoontoastMath()) {
-                    $this->assertEquals($test['int'], (string) $uuid->getInteger());
+                    $this->assertEquals($test['int'], (string)$uuid->getInteger());
                 }
                 $this->assertEquals($test['fields'], $uuid->getFieldsHex());
                 $this->assertEquals($test['fields']['time_low'], $uuid->getTimeLowHex());

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -1270,7 +1270,7 @@ class UuidTest extends TestCase
 
         $featureSet->setTimeProvider($timeOfDay);
 
-        Uuid::setFactory(new UuidFactory($featureSet));;
+        Uuid::setFactory(new UuidFactory($featureSet));
         $uuidB = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
         $this->assertEquals('1419d680-d292-1165-9669-00007ffffffe', (string)$uuidB);


### PR DESCRIPTION
Fixes https://github.com/ramsey/uuid/issues/131

- Added test cases for equals, compareTo, and fromString. 
- Added strtolower in fromString so all UUID created from a string will be converted into lowercase. 