### PR TITLE
Unit Tests: Add function mock test for systems without libsodium

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "apigen/apigen": "^4.1",
         "mockery/mockery": "^0.9.4",
         "goaop/framework": "1.0.0-alpha.2",
-        "codeception/aspect-mock": "1.0.0"
+        "codeception/aspect-mock": "1.0.0",
+        "php-mock/php-mock-phpunit": "^1.1"
     },
     "suggest": {
         "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "mockery/mockery": "^0.9.4",
         "goaop/framework": "1.0.0-alpha.2",
         "codeception/aspect-mock": "1.0.0",
-        "php-mock/php-mock-phpunit": "^1.1"
+        "php-mock/php-mock-phpunit": "^0.3|^1.1"
     },
     "suggest": {
         "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",

--- a/tests/Generator/SodiumRandomGeneratorTest.php
+++ b/tests/Generator/SodiumRandomGeneratorTest.php
@@ -57,5 +57,4 @@ class SodiumRandomGeneratorTest extends TestCase
         $generator = new SodiumRandomGenerator();
         $generator->generate(10);
     }
-
 }


### PR DESCRIPTION
This test allows the UUID library to have coverage of the collaboration between this Generator and libsodium, without the test-runner having to have that library installed. This helps improve coverage and ensure that someone doesn't break that generator and not know it because they can't run the test. 

Because this introduces a new library for function mocking, I wanted to do it as just a small PR for this one test. That library could then be used for a lot of other collaboration tests which are currently being skipped on a lot of systems, if you decide to merge this. 

(Edited for clarity)