### PR TITLE
Update AOP framework to latest 1.0 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "satooshi/php-coveralls": "^0.6.1",
         "apigen/apigen": "^4.1",
         "mockery/mockery": "^0.9.4",
-        "goaop/framework": "1.0.0-alpha.2",
+        "goaop/framework": "^1.0.0",
         "codeception/aspect-mock": "1.0.0",
         "php-mock/php-mock-phpunit": "^0.3|^1.1"
     },


### PR DESCRIPTION
I was getting a lot of errors when running tests.

```
PHPUnit_Framework_Exception: PHP Notice:  Undefined index: Doctrine\Common\Annotations\ in /home/leigh/uuid/vendor/goaop/framework/src/Instrument/ClassLoading/AopComposerLoader.php on line 78
```

This seems to have been fixed since the alpha version of Go! AOP, and all tests pass after upgrading to the latest version (1.0.2).

