### PR TITLE
Pin doctrine/annotations to a 1.2.x version (Fixes build)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "apigen/apigen": "^4.1",
         "mockery/mockery": "^0.9.4",
         "goaop/framework": "1.0.0-alpha.2",
+        "doctrine/annotations": "~1.2.0",
         "codeception/aspect-mock": "1.0.0",
         "php-mock/php-mock-phpunit": "^0.3|^1.1"
     },


### PR DESCRIPTION
1.3.x is currently causing test failures when used with goaop
1.0.0-alpha2 (which we are pinned at for PHP 5.4 compat)