### PR TITLE
Optimize UUID string decoding

### DIFF
--- a/src/Codec/StringCodec.php
+++ b/src/Codec/StringCodec.php
@@ -156,12 +156,12 @@ class StringCodec implements CodecInterface
     protected function getFields(array $components)
     {
         return array(
-            'time_low' => sprintf('%08s', $components[0]),
-            'time_mid' => sprintf('%04s', $components[1]),
-            'time_hi_and_version' => sprintf('%04s', $components[2]),
-            'clock_seq_hi_and_reserved' => sprintf('%02s', substr($components[3], 0, 2)),
-            'clock_seq_low' => sprintf('%02s', substr($components[3], 2)),
-            'node' => sprintf('%012s', $components[4])
+            'time_low' => str_pad($components[0], 8, '0', STR_PAD_LEFT),
+            'time_mid' => str_pad($components[1], 4, '0', STR_PAD_LEFT),
+            'time_hi_and_version' => str_pad($components[2], 4, '0', STR_PAD_LEFT),
+            'clock_seq_hi_and_reserved' => str_pad(substr($components[3], 0, 2), 2, '0', STR_PAD_LEFT),
+            'clock_seq_low' => str_pad(substr($components[3], 2), 2, '0', STR_PAD_LEFT),
+            'node' => str_pad($components[4], 12, '0', STR_PAD_LEFT)
         );
     }
 }


### PR DESCRIPTION
I realized that 30% of the request time in our app is spent by hydrating the uuid (We are using Doctrine and in this specific request I was accidentally hydrating few thousands entities).

Luckily, I remembered the #160 and tried to do similar optimization for uuid decoding. It resulted in 10-20% performance improvement (it is not much, but every millisecond counts).

Benchmark: last commit in https://github.com/mhujer/uuid/commits/mh-uuid-decoding-speedup-benchmark
Benchmark results (Blackfire): https://blackfire.io/profiles/compare/42276a3a-cb45-47e2-80c4-61420b3c61bd/graph