### PR TITLE
allow valid uuid hex strings to pass isValid method

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -629,11 +629,34 @@ class Uuid implements UuidInterface
             return true;
         }
 
+        if (self::looksLikeHex($uuid)) {
+            try {
+                $uuid = self::fromString($uuid);
+            } catch (\InvalidArgumentException $e) {
+                return false;
+            }
+        }
+
         if (!preg_match('/' . self::VALID_PATTERN . '/', $uuid)) {
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Simple test to see if string could be a 32 char hex
+     * 
+     * @param  string $uuid The string UUID to test
+     * @return boolean
+     */
+    private static function looksLikeHex($uuid)
+    {
+        if (strlen($uuid) === 32) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -96,6 +96,11 @@ class Uuid implements UuidInterface
     const VALID_PATTERN = '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$';
 
     /**
+     * Regular expression pattern to add dashes to a hex string
+     */
+    const STRING_SEGMENTS = '(\w{8})(\w{4})(\w{4})(\w{4})(\w{12})';
+
+    /**
      * The factory to use when creating UUIDs.
      * @var UuidFactoryInterface
      */
@@ -629,12 +634,8 @@ class Uuid implements UuidInterface
             return true;
         }
 
-        if (self::looksLikeHex($uuid)) {
-            try {
-                $uuid = self::fromString($uuid);
-            } catch (\InvalidArgumentException $e) {
-                return false;
-            }
+        if (strlen($uuid) === 32) {
+            $uuid = preg_replace('/' . self::STRING_SEGMENTS . '/', '$1-$2-$3-$4-$5', $uuid);
         }
 
         if (!preg_match('/' . self::VALID_PATTERN . '/', $uuid)) {
@@ -646,7 +647,7 @@ class Uuid implements UuidInterface
 
     /**
      * Simple test to see if string could be a 32 char hex
-     * 
+     *
      * @param  string $uuid The string UUID to test
      * @return boolean
      */

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -1419,7 +1419,7 @@ class UuidTest extends TestCase
     public function testIsValidNoDashes()
     {
         $valid = Uuid::isValid('af6f8cb0c57d11e19b210800200c9a66');
-        $this->assertFalse($valid);
+        $this->assertTrue($valid);
     }
 
     /**


### PR DESCRIPTION
If a hex string can be converted to a Uuid without exception, it should be valid.