### PR TITLE
Multicast Bit not Set

### DIFF
--- a/src/Provider/Node/RandomNodeProvider.php
+++ b/src/Provider/Node/RandomNodeProvider.php
@@ -31,6 +31,6 @@ class RandomNodeProvider implements NodeProviderInterface
      */
     public function getNode()
     {
-        return sprintf('%06x%06x', mt_rand(0, 0xffffff), mt_rand(0, 0xffffff));
+        return sprintf('%06x%06x', mt_rand(0, 0xffffff), mt_rand(0, 0xffffff) | 0x01);
     }
 }


### PR DESCRIPTION
Per RFC 4122, 4.6:

>  For systems with no IEEE address, a randomly or pseudo-randomly generated value may be used; see Section 4.5.  The multicast bit must be set in such addresses, in order that they will never conflict with addresses obtained from network cards.

and 4.5:

> A better solution is to obtain a 47-bit cryptographic quality random number and use it as the low 47 bits of the node ID, with the least significant bit of the first octet of the node ID set to one.  This bit is the unicast/multicast bit, which will never be set in IEEE 802 addresses obtained from network cards.  Hence, there can never be a conflict between UUIDs generated by machines with and without network cards.  (Recall that the IEEE 802 spec talks about transmission order, which is the opposite of the in-memory representation that is discussed in this document.)

> For compatibility with earlier specifications, note that this document uses the unicast/multicast bit, instead of the arguably more correct local/global bit.

Thus, the Least Significant Bit of the randomly-generated node ID should be set to 1 to indicate that it is a randomly-generated node ID.

Proposed change is to flip the least-significant bit of the second randomly-generated number via inclusive OR bitwise operator.