### PR TITLE
Add feature to use sysfs interface to get node identifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 
 script:
   - ./vendor/bin/parallel-lint src tests
-  - ./vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml
+  - travis_wait ./vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml
   - ./vendor/bin/phpcs src tests --standard=psr2 -sp
 
 after_success:

--- a/src/Provider/Node/SystemNodeProvider.php
+++ b/src/Provider/Node/SystemNodeProvider.php
@@ -39,11 +39,11 @@ class SystemNodeProvider implements NodeProviderInterface
         $matches = array();
 
         // first try a  linux specific way
-
         $node = $this->getsysfs();
+
         // Search the ifconfig output for all MAC addresses and return
         // the first one found
-        if ($node !== false) {
+        if ($node === false) {
             if (preg_match_all($pattern, $this->getIfconfig(), $matches, PREG_PATTERN_ORDER)) {
                 $node = $matches[1][0];
             }
@@ -86,6 +86,7 @@ class SystemNodeProvider implements NodeProviderInterface
      */
     protected function getsysfs()
     {
+        $mac = false;
         if (strtoupper(php_uname('s')) === "LINUX") {
             // get all the macadresses of all systems
             $macs = array_map(

--- a/src/Provider/Node/SystemNodeProvider.php
+++ b/src/Provider/Node/SystemNodeProvider.php
@@ -38,14 +38,19 @@ class SystemNodeProvider implements NodeProviderInterface
         $pattern = '/[^:]([0-9A-Fa-f]{2}([:-])[0-9A-Fa-f]{2}(\2[0-9A-Fa-f]{2}){4})[^:]/';
         $matches = array();
 
+        // first try a  linux specific way
+
+        $node = $this->getsysfs();
         // Search the ifconfig output for all MAC addresses and return
         // the first one found
-        $node = false;
-        if (preg_match_all($pattern, $this->getIfconfig(), $matches, PREG_PATTERN_ORDER)) {
-            $node = $matches[1][0];
+        if ($node !== false) {
+            if (preg_match_all($pattern, $this->getIfconfig(), $matches, PREG_PATTERN_ORDER)) {
+                $node = $matches[1][0];
+            }
+        }
+        if ($node !== false) {
             $node = str_replace([':', '-'], '', $node);
         }
-
         return $node;
     }
 
@@ -72,5 +77,35 @@ class SystemNodeProvider implements NodeProviderInterface
         }
 
         return ob_get_clean();
+    }
+
+    /**
+     * Returns mac address from the first system interface via the sysfs interface
+     *
+     * @return string|bool
+     */
+    protected function getsysfs()
+    {
+        if (strtoupper(php_uname('s')) === "LINUX") {
+            // get all the macadresses of all systems
+            $macs = array_map(
+                'file_get_contents',
+                glob('/sys/class/net/*/address', GLOB_NOSORT)
+            );
+
+            $macs = array_map('trim', $macs);
+
+            // remove invalid entries
+            $macs = array_filter($macs, function ($mac) {
+                return
+                    // localhost adapter
+                    $mac !== '00:00:00:00:00:00' &&
+                    // must match  mac adress
+                    preg_match('/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/i', $mac);
+            });
+
+            $mac = reset($macs);
+        }
+        return $mac;
     }
 }

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -223,7 +223,7 @@ class SystemNodeProviderTest extends TestCase
             ->setMethods(['getIfconfig'])
             ->getMock();
 
-        if($os === 'Linux') {
+        if ($os === 'Linux') {
             $provider->expects($this->never())
                 ->method('getIfconfig');
         } else {

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -217,6 +217,10 @@ class SystemNodeProviderTest extends TestCase
     public function testCallGetsysfsOnLinux($os)
     {
         AspectMock::func('Ramsey\Uuid\Provider\Node', 'php_uname', $os);
+        AspectMock::func('Ramsey\Uuid\Provider\Node', 'glob', [
+            'data://text/plain,00:00:00:00:00:00',
+            'data://text/plain,01:02:03:04:05:06',
+        ]);
 
         //Using a mock to verify the provider only gets the node from ifconfig one time
         $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
@@ -235,5 +239,6 @@ class SystemNodeProviderTest extends TestCase
                 ->willReturn(PHP_EOL . '01-02-03-04-05-06' . PHP_EOL);
         }
         $node = $provider->getNode();
+        $this->assertEquals('010203040506', $node);
     }
 }

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -15,8 +15,12 @@ class SystemNodeProviderTest extends TestCase
     public function testGetNodeReturnsSystemNodeFromMacAddress()
     {
         $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
-            ->setMethods(['getIfconfig'])
+            ->setMethods(['getIfconfig','getsysfs'])
             ->getMock();
+
+        $provider->expects($this->once())
+            ->method('getsysfs')
+            ->willReturn(false);
 
         $provider->expects($this->once())
             ->method('getIfconfig')
@@ -50,10 +54,14 @@ class SystemNodeProviderTest extends TestCase
     {
         //Using a stub to provide data for the protected method that gets the node
         $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
-            ->setMethods(['getIfconfig'])
+            ->setMethods(['getIfconfig','getsysfs'])
             ->getMock();
         $provider->method('getIfconfig')
             ->willReturn(PHP_EOL . $formatted . PHP_EOL);
+
+        $provider->expects($this->once())
+            ->method('getsysfs')
+            ->willReturn(false);
 
         $node = $provider->getNode();
         $this->assertEquals($expected, $node);
@@ -67,12 +75,16 @@ class SystemNodeProviderTest extends TestCase
     {
         //Using a stub to provide data for the protected method that gets the node
         $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
-            ->setMethods(['getIfconfig'])
+            ->setMethods(['getIfconfig','getsysfs'])
             ->getMock();
         $provider->method('getIfconfig')
             ->willReturn(PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL .
                 '00-11-22-33-44-55' . PHP_EOL .
                 'FF-11-EE-22-DD-33' . PHP_EOL);
+
+        $provider->expects($this->once())
+            ->method('getsysfs')
+            ->willReturn(false);
 
         $node = $provider->getNode();
         $this->assertEquals('AABBCCDDEEFF', $node);
@@ -85,12 +97,16 @@ class SystemNodeProviderTest extends TestCase
     public function testGetNodeReturnsFalseWhenNodeIsNotFound()
     {
         $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
-            ->setMethods(['getIfconfig'])
+            ->setMethods(['getIfconfig','getsysfs'])
             ->getMock();
 
         $provider->expects($this->once())
             ->method('getIfconfig')
             ->willReturn('some string that does not match the mac address');
+
+        $provider->expects($this->once())
+            ->method('getsysfs')
+            ->willReturn(false);
 
         $node = $provider->getNode();
         $this->assertFalse($node);
@@ -103,12 +119,16 @@ class SystemNodeProviderTest extends TestCase
     public function testGetNodeWillNotExecuteSystemCallIfFailedFirstTime()
     {
         $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
-            ->setMethods(['getIfconfig'])
+            ->setMethods(['getIfconfig','getsysfs'])
             ->getMock();
 
         $provider->expects($this->once())
             ->method('getIfconfig')
             ->willReturn('some string that does not match the mac address');
+
+        $provider->expects($this->once())
+            ->method('getsysfs')
+            ->willReturn(false);
 
         $provider->getNode();
         $provider->getNode();
@@ -137,7 +157,14 @@ class SystemNodeProviderTest extends TestCase
         AspectMock::func('Ramsey\Uuid\Provider\Node', 'php_uname', $os);
         $passthru = AspectMock::func('Ramsey\Uuid\Provider\Node', 'passthru', 'whatever');
 
-        $provider = new SystemNodeProvider();
+        $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
+            ->setMethods(['getsysfs'])
+            ->getMock();
+
+        $provider->expects($this->once())
+            ->method('getsysfs')
+            ->willReturn(false);
+
         $provider->getNode();
         $passthru->verifyInvokedOnce([$command]);
     }
@@ -168,11 +195,14 @@ class SystemNodeProviderTest extends TestCase
     {
         //Using a mock to verify the provider only gets the node from ifconfig one time
         $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
-            ->setMethods(['getIfconfig'])
+            ->setMethods(['getIfconfig','getsysfs'])
             ->getMock();
         $provider->expects($this->once())
             ->method('getIfconfig')
             ->willReturn(PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL);
+        $provider->expects($this->once())
+            ->method('getsysfs')
+            ->willReturn(false);
         $provider->getNode();
         $provider->getNode();
     }


### PR DESCRIPTION
Linux offers a sysfs interface to the mac addresses of the network
interfaces without calling exec. this fixes #184

This enables repeatable system based UUID generation even on docker images
like php:7 

TODO:
- [x] fix unit testing, it fails on getIfconfig not being called, i think the way of mocking needs to be changed.
- [x] write changelog, when all changes are finalized