### PR TITLE
Fix "PHPUnit_Framework_TestCase::getMock() is deprecated" warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "moontoast/math": "^1.1",
         "ircmaxell/random-lib": "^1.1",
-        "phpunit/phpunit": "^4.7|>=5.0 <5.4",
+        "phpunit/phpunit": "^4.7|^5.0",
         "squizlabs/php_codesniffer": "^2.3",
         "jakub-onderka/php-parallel-lint": "^0.9.0",
         "satooshi/php-coveralls": "^0.6.1",

--- a/tests/Builder/DefaultUuidBuilderTest.php
+++ b/tests/Builder/DefaultUuidBuilderTest.php
@@ -14,9 +14,9 @@ class DefaultUuidBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildCreatesUuid()
     {
-        $converter = $this->getMock('Ramsey\Uuid\Converter\NumberConverterInterface');
+        $converter = $this->getMockBuilder('Ramsey\Uuid\Converter\NumberConverterInterface')->getMock();
         $builder = new DefaultUuidBuilder($converter);
-        $codec = $this->getMock('Ramsey\Uuid\Codec\CodecInterface');
+        $codec = $this->getMockBuilder('Ramsey\Uuid\Codec\CodecInterface')->getMock();
 
         $fields = [
             'time_low' => '754cd475',

--- a/tests/Builder/DegradedUuidBuilderTest.php
+++ b/tests/Builder/DegradedUuidBuilderTest.php
@@ -14,9 +14,9 @@ class DegradedUuidBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildCreatesUuid()
     {
-        $converter = $this->getMock('Ramsey\Uuid\Converter\NumberConverterInterface');
+        $converter = $this->getMockBuilder('Ramsey\Uuid\Converter\NumberConverterInterface')->getMock();
         $builder = new DegradedUuidBuilder($converter);
-        $codec = $this->getMock('Ramsey\Uuid\Codec\CodecInterface');
+        $codec = $this->getMockBuilder('Ramsey\Uuid\Codec\CodecInterface')->getMock();
 
         $fields = [
             'time_low' => '754cd475',

--- a/tests/Codec/GuidStringCodecTest.php
+++ b/tests/Codec/GuidStringCodecTest.php
@@ -25,8 +25,8 @@ class GuidStringCodecTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->builder = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
-        $this->uuid = $this->getMock('Ramsey\Uuid\UuidInterface');
+        $this->builder = $this->getMockBuilder('Ramsey\Uuid\Builder\UuidBuilderInterface')->getMock();
+        $this->uuid = $this->getMockBuilder('Ramsey\Uuid\UuidInterface')->getMock();
         $this->fields = ['time_low' => '12345678',
             'time_mid' => '1234',
             'time_hi_and_version' => 'abcd',

--- a/tests/Codec/OrderedTimeCodecTest.php
+++ b/tests/Codec/OrderedTimeCodecTest.php
@@ -29,8 +29,8 @@ class OrderedTimeCodecTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->builder = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
-        $this->uuid = $this->getMock('Ramsey\Uuid\UuidInterface');
+        $this->builder = $this->getMockBuilder('Ramsey\Uuid\Builder\UuidBuilderInterface')->getMock();
+        $this->uuid = $this->getMockBuilder('Ramsey\Uuid\UuidInterface')->getMock();
         $this->fields = ['time_low' => '58e0a7d7',
             'time_mid' => 'eebc',
             'time_hi_and_version' => '11d8',

--- a/tests/Codec/StringCodecTest.php
+++ b/tests/Codec/StringCodecTest.php
@@ -27,8 +27,8 @@ class StringCodecTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->builder = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
-        $this->uuid = $this->getMock('Ramsey\Uuid\UuidInterface');
+        $this->builder = $this->getMockBuilder('Ramsey\Uuid\Builder\UuidBuilderInterface')->getMock();
+        $this->uuid = $this->getMockBuilder('Ramsey\Uuid\UuidInterface')->getMock();
         $this->fields = ['time_low' => '12345678',
             'time_mid' => '1234',
             'time_hi_and_version' => 'abcd',

--- a/tests/Encoder/TimestampFirstCombCodecTest.php
+++ b/tests/Encoder/TimestampFirstCombCodecTest.php
@@ -20,13 +20,13 @@ class TimestampFirstCombCodecTest extends TestCase
 
     protected function setUp()
     {
-        $this->builderMock = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
+        $this->builderMock = $this->getMockBuilder('Ramsey\Uuid\Builder\UuidBuilderInterface')->getMock();
         $this->codec = new TimestampFirstCombCodec($this->builderMock);
     }
 
     public function testEncoding()
     {
-        $uuidMock = $this->getMock('Ramsey\Uuid\UuidInterface');
+        $uuidMock = $this->getMockBuilder('Ramsey\Uuid\UuidInterface')->getMock();
         $uuidMock->expects($this->any())
             ->method('getFieldsHex')
             ->willReturn(array('ff6f8cb0', 'c57d', '11e1', '9b', '21', '0800200c9a66'));
@@ -37,7 +37,7 @@ class TimestampFirstCombCodecTest extends TestCase
 
     public function testBinaryEncoding()
     {
-        $uuidMock = $this->getMock('Ramsey\Uuid\UuidInterface');
+        $uuidMock = $this->getMockBuilder('Ramsey\Uuid\UuidInterface')->getMock();
         $uuidMock->expects($this->any())
             ->method('getFieldsHex')
             ->willReturn(array('ff6f8cb0', 'c57d', '11e1', '9b', '21', '0800200c9a66'));

--- a/tests/Encoder/TimestampLastCombCodecTest.php
+++ b/tests/Encoder/TimestampLastCombCodecTest.php
@@ -20,13 +20,13 @@ class TimestampLastCombCodecTest extends TestCase
 
     protected function setUp()
     {
-        $this->builderMock = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
+        $this->builderMock = $this->getMockBuilder('Ramsey\Uuid\Builder\UuidBuilderInterface')->getMock();
         $this->codec = new TimestampLastCombCodec($this->builderMock);
     }
 
     public function testEncoding()
     {
-        $uuidMock = $this->getMock('Ramsey\Uuid\UuidInterface');
+        $uuidMock = $this->getMockBuilder('Ramsey\Uuid\UuidInterface')->getMock();
         $uuidMock->expects($this->any())
             ->method('getFieldsHex')
             ->willReturn(array('0800200c', '9a66', '11e1', '9b', '21', 'ff6f8cb0c57d'));
@@ -37,7 +37,7 @@ class TimestampLastCombCodecTest extends TestCase
 
     public function testBinaryEncoding()
     {
-        $uuidMock = $this->getMock('Ramsey\Uuid\UuidInterface');
+        $uuidMock = $this->getMockBuilder('Ramsey\Uuid\UuidInterface')->getMock();
         $uuidMock->expects($this->any())
             ->method('getHex')
             ->willReturn('0800200c9a6611e19b21ff6f8cb0c57d');

--- a/tests/Generator/CombGeneratorTest.php
+++ b/tests/Generator/CombGeneratorTest.php
@@ -18,19 +18,19 @@ class CombGeneratorTest extends TestCase
     {
         $length = 10;
         $expectedLength = ($length - $this->timestampBytes);
-        $randomGenerator = $this->getMock('Ramsey\Uuid\Generator\RandomGeneratorInterface');
+        $randomGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
         $randomGenerator->expects($this->once())
             ->method('generate')
             ->with($expectedLength);
-        $converter = $this->getMock('Ramsey\Uuid\Converter\NumberConverterInterface');
+        $converter = $this->getMockBuilder('Ramsey\Uuid\Converter\NumberConverterInterface')->getMock();
         $generator = new CombGenerator($randomGenerator, $converter);
         $generator->generate($length);
     }
 
     public function testGenerateCalculatesPaddedHexStringFromCurrentTimestamp()
     {
-        $randomGenerator = $this->getMock('Ramsey\Uuid\Generator\RandomGeneratorInterface');
-        $converter = $this->getMock('Ramsey\Uuid\Converter\NumberConverterInterface');
+        $randomGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
+        $converter = $this->getMockBuilder('Ramsey\Uuid\Converter\NumberConverterInterface')->getMock();
         $converter->expects($this->once())
             ->method('toHex')
             ->with($this->isType('string'));
@@ -44,12 +44,12 @@ class CombGeneratorTest extends TestCase
         $hash = dechex(1234567891);
         $timeHash = dechex(1458147405);
 
-        $randomGenerator = $this->getMock('Ramsey\Uuid\Generator\RandomGeneratorInterface');
+        $randomGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
         $randomGenerator->method('generate')
             ->with(($length - $this->timestampBytes))
             ->willReturn($hash);
 
-        $converter = $this->getMock('Ramsey\Uuid\Converter\NumberConverterInterface');
+        $converter = $this->getMockBuilder('Ramsey\Uuid\Converter\NumberConverterInterface')->getMock();
         $converter->method('toHex')
             ->with($this->isType('string'))
             ->willReturn($timeHash);
@@ -74,8 +74,8 @@ class CombGeneratorTest extends TestCase
     public function testGenerateWithLessThanTimestampBytesThrowsException($length)
     {
         $this->setExpectedException('InvalidArgumentException');
-        $randomGenerator = $this->getMock('Ramsey\Uuid\Generator\RandomGeneratorInterface');
-        $converter = $this->getMock('Ramsey\Uuid\Converter\NumberConverterInterface');
+        $randomGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
+        $converter = $this->getMockBuilder('Ramsey\Uuid\Converter\NumberConverterInterface')->getMock();
         $generator = new CombGenerator($randomGenerator, $converter);
         $generator->generate($length);
     }
@@ -86,8 +86,8 @@ class CombGeneratorTest extends TestCase
     public function testGenerateWithOddNumberOverTimestampBytesCausesError()
     {
         $this->setExpectedException('PHPUnit_Framework_Error');
-        $randomGenerator = $this->getMock('Ramsey\Uuid\Generator\RandomGeneratorInterface');
-        $converter = $this->getMock('Ramsey\Uuid\Converter\NumberConverterInterface');
+        $randomGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
+        $converter = $this->getMockBuilder('Ramsey\Uuid\Converter\NumberConverterInterface')->getMock();
         $generator = new CombGenerator($randomGenerator, $converter);
         $generator->generate(7);
     }

--- a/tests/Generator/DefaultTimeGeneratorTest.php
+++ b/tests/Generator/DefaultTimeGeneratorTest.php
@@ -31,9 +31,9 @@ class DefaultTimeGeneratorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->timeProvider = $this->getMock('Ramsey\Uuid\Provider\TimeProviderInterface');
-        $this->nodeProvider = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
-        $this->timeConverter = $this->getMock('Ramsey\Uuid\Converter\TimeConverterInterface');
+        $this->timeProvider = $this->getMockBuilder('Ramsey\Uuid\Provider\TimeProviderInterface')->getMock();
+        $this->nodeProvider = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
+        $this->timeConverter = $this->getMockBuilder('Ramsey\Uuid\Converter\TimeConverterInterface')->getMock();
         $this->currentTime = ["sec" => 1458733431, "usec" => 877449];
         $this->calculatedTime = ["low" => "83cb98e0", "mid" => "98e0", "hi" => "03cb"];
     }

--- a/tests/Generator/TimeGeneratorFactoryTest.php
+++ b/tests/Generator/TimeGeneratorFactoryTest.php
@@ -14,9 +14,9 @@ class TimeGeneratorFactoryTest extends TestCase
 {
     public function testGeneratorReturnsNewGenerator()
     {
-        $timeProvider = $this->getMock('Ramsey\Uuid\Provider\TimeProviderInterface');
-        $nodeProvider = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
-        $timeConverter = $this->getMock('Ramsey\Uuid\Converter\TimeConverterInterface');
+        $timeProvider = $this->getMockBuilder('Ramsey\Uuid\Provider\TimeProviderInterface')->getMock();
+        $nodeProvider = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
+        $timeConverter = $this->getMockBuilder('Ramsey\Uuid\Converter\TimeConverterInterface')->getMock();
 
         $factory = new TimeGeneratorFactory($nodeProvider, $timeConverter, $timeProvider);
         $generator = $factory->getGenerator();

--- a/tests/Provider/Node/FallbackNodeProviderTest.php
+++ b/tests/Provider/Node/FallbackNodeProviderTest.php
@@ -9,11 +9,11 @@ class FallbackNodeProviderTest extends TestCase
 {
     public function testGetNodeCallsGetNodeOnEachProviderUntilNodeFound()
     {
-        $providerWithNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithNode = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
         $providerWithNode->expects($this->once())
             ->method('getNode')
             ->willReturn('57764a07f756');
-        $providerWithoutNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithoutNode = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
         $providerWithoutNode->expects($this->once())
             ->method('getNode')
             ->willReturn(null);
@@ -24,15 +24,15 @@ class FallbackNodeProviderTest extends TestCase
 
     public function testGetNodeReturnsNodeFromFirstProviderWithNode()
     {
-        $providerWithoutNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithoutNode = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
         $providerWithoutNode->expects($this->once())
             ->method('getNode')
             ->willReturn(null);
-        $providerWithNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithNode = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
         $providerWithNode->expects($this->once())
             ->method('getNode')
             ->willReturn('57764a07f756');
-        $anotherProviderWithoutNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $anotherProviderWithoutNode = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
         $anotherProviderWithoutNode->expects($this->never())
             ->method('getNode');
 
@@ -43,7 +43,7 @@ class FallbackNodeProviderTest extends TestCase
 
     public function testGetNodeReturnsNullWhenNoNodesFound()
     {
-        $providerWithoutNode = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
+        $providerWithoutNode = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
         $providerWithoutNode->method('getNode')
             ->willReturn(null);
 

--- a/tests/UuidFactoryTest.php
+++ b/tests/UuidFactoryTest.php
@@ -38,12 +38,12 @@ class UuidFactoryTest extends TestCase
 
     public function testGettersReturnValueFromFeatureSet()
     {
-        $codec = $this->getMock('Ramsey\Uuid\Codec\CodecInterface');
-        $nodeProvider = $this->getMock('Ramsey\Uuid\Provider\NodeProviderInterface');
-        $randomGenerator = $this->getMock('Ramsey\Uuid\Generator\RandomGeneratorInterface');
-        $timeGenerator = $this->getMock('Ramsey\Uuid\Generator\TimeGeneratorInterface');
+        $codec = $this->getMockBuilder('Ramsey\Uuid\Codec\CodecInterface')->getMock();
+        $nodeProvider = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
+        $randomGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
+        $timeGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\TimeGeneratorInterface')->getMock();
 
-        $featureSet = $this->getMock('Ramsey\Uuid\FeatureSet');
+        $featureSet = $this->getMockBuilder('Ramsey\Uuid\FeatureSet')->getMock();
         $featureSet->method('getCodec')->willReturn($codec);
         $featureSet->method('getNodeProvider')->willReturn($nodeProvider);
         $featureSet->method('getRandomGenerator')->willReturn($randomGenerator);
@@ -79,19 +79,19 @@ class UuidFactoryTest extends TestCase
     {
         $uuidFactory = new UuidFactory();
 
-        $codec = $this->getMock('Ramsey\Uuid\Codec\CodecInterface');
+        $codec = $this->getMockBuilder('Ramsey\Uuid\Codec\CodecInterface')->getMock();
         $uuidFactory->setCodec($codec);
         $this->assertEquals($codec, $uuidFactory->getCodec());
 
-        $timeGenerator = $this->getMock('Ramsey\Uuid\Generator\TimeGeneratorInterface');
+        $timeGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\TimeGeneratorInterface')->getMock();
         $uuidFactory->setTimeGenerator($timeGenerator);
         $this->assertEquals($timeGenerator, $uuidFactory->getTimeGenerator());
 
-        $numberConverter = $this->getMock('Ramsey\Uuid\Converter\NumberConverterInterface');
+        $numberConverter = $this->getMockBuilder('Ramsey\Uuid\Converter\NumberConverterInterface')->getMock();
         $uuidFactory->setNumberConverter($numberConverter);
         $this->assertEquals($numberConverter, $uuidFactory->getNumberConverter());
 
-        $uuidBuilder = $this->getMock('Ramsey\Uuid\Builder\UuidBuilderInterface');
+        $uuidBuilder = $this->getMockBuilder('Ramsey\Uuid\Builder\UuidBuilderInterface')->getMock();
         $uuidFactory->setUuidBuilder($uuidBuilder);
         $this->assertEquals($uuidBuilder, $uuidFactory->getUuidBuilder());
     }

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -810,7 +810,7 @@ class UuidTest extends TestCase
      */
     public function testUuid4TimestampLastComb()
     {
-        $mock = $this->getMock('Ramsey\Uuid\Generator\RandomGeneratorInterface');
+        $mock = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
         $mock->expects($this->any())
             ->method('generate')
             ->willReturnCallback(function ($length) {
@@ -842,7 +842,7 @@ class UuidTest extends TestCase
      */
     public function testUuid4TimestampFirstComb()
     {
-        $mock = $this->getMock('Ramsey\Uuid\Generator\RandomGeneratorInterface');
+        $mock = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
         $mock->expects($this->any())
             ->method('generate')
             ->willReturnCallback(function ($length) {


### PR DESCRIPTION
Fixes #186.