### PR TITLE
Drop paragonie/random_compat from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "source": "https://github.com/ramsey/uuid"
     },
     "require": {
-        "php": "^7.0",
-        "paragonie/random_compat": "^2.0"
+        "php": "^7.0"
     },
     "require-dev": {
         "ext-gmp": "*",


### PR DESCRIPTION
It is not necessary anymore, because the minimal required version was already set to 7.0