### PR TITLE
[4.x] Use ::class constants where possible

### DIFF
--- a/tests/Codec/OrderedTimeCodecTest.php
+++ b/tests/Codec/OrderedTimeCodecTest.php
@@ -29,8 +29,8 @@ class OrderedTimeCodecTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->builder = $this->getMockBuilder('Ramsey\Uuid\Builder\UuidBuilderInterface')->getMock();
-        $this->uuid = $this->getMockBuilder('Ramsey\Uuid\UuidInterface')->getMock();
+        $this->builder = $this->getMockBuilder(UuidBuilderInterface::class)->getMock();
+        $this->uuid = $this->getMockBuilder(UuidInterface::class)->getMock();
         $this->fields = ['time_low' => '58e0a7d7',
             'time_mid' => 'eebc',
             'time_hi_and_version' => '11d8',

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -15,7 +15,7 @@ class SystemNodeProviderTest extends TestCase
     public function testGetNodeReturnsSystemNodeFromMacAddress()
     {
         /** @var \Ramsey\Uuid\Provider\Node\SystemNodeProvider|\PHPUnit_Framework_MockObject_MockObject $provider */
-        $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
+        $provider = $this->getMockBuilder(SystemNodeProvider::class)
             ->setMethods(['getIfconfig'])
             ->getMock();
 
@@ -88,7 +88,7 @@ class SystemNodeProviderTest extends TestCase
     public function testGetNodeReturnsFalseWhenNodeIsNotFound()
     {
         /** @var \Ramsey\Uuid\Provider\Node\SystemNodeProvider|\PHPUnit_Framework_MockObject_MockObject $provider */
-        $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
+        $provider = $this->getMockBuilder(SystemNodeProvider::class)
             ->setMethods(['getIfconfig'])
             ->getMock();
 
@@ -107,7 +107,7 @@ class SystemNodeProviderTest extends TestCase
     public function testGetNodeWillNotExecuteSystemCallIfFailedFirstTime()
     {
         /** @var \Ramsey\Uuid\Provider\Node\SystemNodeProvider|\PHPUnit_Framework_MockObject_MockObject $provider */
-        $provider = $this->getMockBuilder('Ramsey\Uuid\Provider\Node\SystemNodeProvider')
+        $provider = $this->getMockBuilder(SystemNodeProvider::class)
             ->setMethods(['getIfconfig'])
             ->getMock();
 

--- a/tests/UuidFactoryTest.php
+++ b/tests/UuidFactoryTest.php
@@ -4,6 +4,12 @@ namespace Ramsey\Uuid\Test;
 
 use Ramsey\Uuid\FeatureSet;
 use Ramsey\Uuid\UuidFactory;
+use Ramsey\Uuid\Codec\CodecInterface;
+use Ramsey\Uuid\Generator\RandomGeneratorInterface;
+use Ramsey\Uuid\Provider\NodeProviderInterface;
+use Ramsey\Uuid\Generator\TimeGeneratorInterface;
+use Ramsey\Uuid\Converter\NumberConverterInterface;
+use Ramsey\Uuid\Builder\UuidBuilderInterface;
 
 class UuidFactoryTest extends TestCase
 {
@@ -38,12 +44,12 @@ class UuidFactoryTest extends TestCase
 
     public function testGettersReturnValueFromFeatureSet()
     {
-        $codec = $this->getMockBuilder('Ramsey\Uuid\Codec\CodecInterface')->getMock();
-        $nodeProvider = $this->getMockBuilder('Ramsey\Uuid\Provider\NodeProviderInterface')->getMock();
-        $randomGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
-        $timeGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\TimeGeneratorInterface')->getMock();
+        $codec = $this->getMockBuilder(CodecInterface::class)->getMock();
+        $nodeProvider = $this->getMockBuilder(NodeProviderInterface::class)->getMock();
+        $randomGenerator = $this->getMockBuilder(RandomGeneratorInterface::class)->getMock();
+        $timeGenerator = $this->getMockBuilder(TimeGeneratorInterface::class)->getMock();
 
-        $featureSet = $this->getMockBuilder('Ramsey\Uuid\FeatureSet')->getMock();
+        $featureSet = $this->getMockBuilder(FeatureSet::class)->getMock();
         $featureSet->method('getCodec')->willReturn($codec);
         $featureSet->method('getNodeProvider')->willReturn($nodeProvider);
         $featureSet->method('getRandomGenerator')->willReturn($randomGenerator);
@@ -79,19 +85,19 @@ class UuidFactoryTest extends TestCase
     {
         $uuidFactory = new UuidFactory();
 
-        $codec = $this->getMockBuilder('Ramsey\Uuid\Codec\CodecInterface')->getMock();
+        $codec = $this->getMockBuilder(CodecInterface::class)->getMock();
         $uuidFactory->setCodec($codec);
         $this->assertEquals($codec, $uuidFactory->getCodec());
 
-        $timeGenerator = $this->getMockBuilder('Ramsey\Uuid\Generator\TimeGeneratorInterface')->getMock();
+        $timeGenerator = $this->getMockBuilder(TimeGeneratorInterface::class)->getMock();
         $uuidFactory->setTimeGenerator($timeGenerator);
         $this->assertEquals($timeGenerator, $uuidFactory->getTimeGenerator());
 
-        $numberConverter = $this->getMockBuilder('Ramsey\Uuid\Converter\NumberConverterInterface')->getMock();
+        $numberConverter = $this->getMockBuilder(NumberConverterInterface::class)->getMock();
         $uuidFactory->setNumberConverter($numberConverter);
         $this->assertEquals($numberConverter, $uuidFactory->getNumberConverter());
 
-        $uuidBuilder = $this->getMockBuilder('Ramsey\Uuid\Builder\UuidBuilderInterface')->getMock();
+        $uuidBuilder = $this->getMockBuilder(UuidBuilderInterface::class)->getMock();
         $uuidFactory->setUuidBuilder($uuidBuilder);
         $this->assertEquals($uuidBuilder, $uuidFactory->getUuidBuilder());
     }

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -12,6 +12,10 @@ use Ramsey\Uuid\Provider\Time\SystemTimeProvider;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use Ramsey\Uuid\Validator\Validator;
+use Ramsey\Uuid\Generator\RandomGeneratorInterface;
+use Ramsey\Uuid\Validator\ValidatorInterface;
+use Ramsey\Uuid\DegradedUuid;
+use Ramsey\Uuid\Converter\Number\DegradedNumberConverter;
 
 class UuidTest extends TestCase
 {
@@ -252,8 +256,8 @@ class UuidTest extends TestCase
 
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
 
-        $this->assertInstanceOf('Ramsey\Uuid\DegradedUuid', $uuid);
-        $this->assertInstanceOf('Ramsey\Uuid\Converter\Number\DegradedNumberConverter', $uuid->getNumberConverter());
+        $this->assertInstanceOf(DegradedUuid::class, $uuid);
+        $this->assertInstanceOf(DegradedNumberConverter::class, $uuid->getNumberConverter());
 
         $date = $uuid->getDateTime();
     }
@@ -881,7 +885,7 @@ class UuidTest extends TestCase
     public function testUuid4()
     {
         $uuid = Uuid::uuid4();
-        $this->assertInstanceOf('Ramsey\Uuid\Uuid', $uuid);
+        $this->assertInstanceOf(Uuid::class, $uuid);
         $this->assertEquals(2, $uuid->getVariant());
         $this->assertEquals(4, $uuid->getVersion());
     }
@@ -892,7 +896,7 @@ class UuidTest extends TestCase
      */
     public function testUuid4TimestampLastComb()
     {
-        $mock = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
+        $mock = $this->getMockBuilder(RandomGeneratorInterface::class)->getMock();
         $mock->expects($this->any())
             ->method('generate')
             ->willReturnCallback(function ($length) {
@@ -924,7 +928,7 @@ class UuidTest extends TestCase
      */
     public function testUuid4TimestampFirstComb()
     {
-        $mock = $this->getMockBuilder('Ramsey\Uuid\Generator\RandomGeneratorInterface')->getMock();
+        $mock = $this->getMockBuilder(RandomGeneratorInterface::class)->getMock();
         $mock->expects($this->any())
             ->method('generate')
             ->willReturnCallback(function ($length) {
@@ -1626,7 +1630,7 @@ class UuidTest extends TestCase
     {
         $argument = uniqid('passed argument ');
 
-        $validator = $this->getMockBuilder('Ramsey\Uuid\Validator\ValidatorInterface')->getMock();
+        $validator = $this->getMockBuilder(ValidatorInterface::class)->getMock();
         $validator->expects($this->once())->method('validate')->with($argument)->willReturn(true);
         /** @var UuidFactory $factory */
         $factory = Uuid::getFactory();
@@ -1642,8 +1646,8 @@ class UuidTest extends TestCase
      */
     public function testUsingNilAsValidUuid()
     {
-        $this->assertInstanceOf('Ramsey\Uuid\Uuid', Uuid::uuid3(Uuid::NIL, 'randomtext'));
-        $this->assertInstanceOf('Ramsey\Uuid\Uuid', Uuid::uuid5(Uuid::NIL, 'randomtext'));
+        $this->assertInstanceOf(Uuid::class, Uuid::uuid3(Uuid::NIL, 'randomtext'));
+        $this->assertInstanceOf(Uuid::class, Uuid::uuid5(Uuid::NIL, 'randomtext'));
     }
 
     /**

--- a/tests/Validator/ValidatorTest.php
+++ b/tests/Validator/ValidatorTest.php
@@ -3,6 +3,7 @@
 namespace Ramsey\Uuid\Test\Validator;
 
 use Ramsey\Uuid\Test\TestCase;
+use Ramsey\Uuid\Validator\Validator;
 
 /**
  * @coversDefaultClass Ramsey\Uuid\Validator\Validator
@@ -14,7 +15,7 @@ class ValidatorTest extends TestCase
     public function setUp()
     {
         // Disable calls to the constructor, but do not override any methods
-        $this->validator = $this->getMockBuilder('Ramsey\Uuid\Validator\Validator')
+        $this->validator = $this->getMockBuilder(Validator::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();


### PR DESCRIPTION
It helps with refactorings and static analysis, because you can easily tell if the class is referenced or not.