### PR TITLE
[4.x] Use specific versions of require-dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,18 +29,18 @@
     },
     "require-dev": {
         "ext-gmp": "*",
-        "codeception/aspect-mock": "^2.0",
-        "doctrine/annotations": "^1.2",
-        "goaop/framework": "^2.1",
-        "ircmaxell/random-lib": "^1.1",
-        "jakub-onderka/php-parallel-lint": "^0.9.0",
-        "mockery/mockery": "^1.0",
-        "moontoast/math": "^1.1",
-        "php-mock/php-mock-phpunit": "^2.0",
+        "codeception/aspect-mock": "2.1.1",
+        "doctrine/annotations": "1.4.0",
+        "goaop/framework": "2.1.2",
+        "ircmaxell/random-lib": "1.2.0",
+        "jakub-onderka/php-parallel-lint": "0.9.2",
+        "mockery/mockery": "1.0",
+        "moontoast/math": "1.1.2",
+        "php-mock/php-mock-phpunit": "2.0.1",
         "phpstan/phpstan-phpunit": "0.9.2",
         "phpstan/phpstan-shim": "0.9.1",
-        "phpunit/phpunit": "^6.4",
-        "squizlabs/php_codesniffer": "^3.0"
+        "phpunit/phpunit": "6.4.4",
+        "squizlabs/php_codesniffer": "3.2.2"
     },
     "suggest": {
         "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",


### PR DESCRIPTION
It may help to prevent issues such as https://github.com/ramsey/uuid/commit/bd7f7f3135b1cd751b8be06b66a721e13f3d5b06 when a BC break is introduced in a non-semver manner.

On one hand, it means that from time to time, versions need to be updated manually. But on the other hand it allows to handle updates of dev dependencies intentionally, without colliding with other changes (e.g. fix in an older version)

_// If you don't want to merge this, just close the PR. It wasn't that much work so I created the PR directly, instead of creating an issue/discussion first._