### PR TITLE
RandomNodeProviderTest can run only on 64bit

### DIFF
--- a/tests/Provider/Node/RandomNodeProviderTest.php
+++ b/tests/Provider/Node/RandomNodeProviderTest.php
@@ -20,6 +20,8 @@ class RandomNodeProviderTest extends TestCase
      */
     public function testGetNodeUsesRandomBytes()
     {
+        $this->skip64BitTest();
+
         $hexNode = '38a675685d5';
         $bytes = pack('H*', $hexNode);
         $expectedNode = '39a675685d50';
@@ -38,6 +40,8 @@ class RandomNodeProviderTest extends TestCase
      */
     public function testGetNodeSetsMulticastBit()
     {
+        $this->skip64BitTest();
+
         $bytes = pack('H*', base_convert(decbin(3892974093781), 2, 16));
         $expectedBytesHex = '38a675685d50';
         $decimal = 62287585500496;
@@ -57,6 +61,8 @@ class RandomNodeProviderTest extends TestCase
      */
     public function testGetNodeAlreadyHasMulticastBit()
     {
+        $this->skip64BitTest();
+
         $bytes = pack('H*', base_convert(decbin(4492974093781), 2, 16));
         $expectedBytesHex = '4161a1ff5d50';
         $decimal = 71887585500496;
@@ -78,6 +84,8 @@ class RandomNodeProviderTest extends TestCase
      */
     public function testGetNodeSetsMulticastBitForLowNodeValue()
     {
+        $this->skip64BitTest();
+
         $bytes = pack('H*', base_convert(decbin(1), 2, 16));
         $expectedBytesHex = '10';
         $decimal = 16;
@@ -93,6 +101,8 @@ class RandomNodeProviderTest extends TestCase
 
     public function testGetNodeAlwaysSetsMulticastBit()
     {
+        $this->skip64BitTest();
+
         $provider = new RandomNodeProvider();
 
         $this->assertSame('010000000000', sprintf('%012x', hexdec($provider->getNode()) & 0x010000000000));


### PR DESCRIPTION
Tests cannot be ran on 32bit build on Windows, because of the int overflow.

----

I also think that an exception should be added to `RandomNodeProvider::getNode()` on 32bit system, in case someone uses it accidentally, because it provides less randomness than expected:

See output from https://3v4l.org/SJiKq
```
string(12) "ffca431bbc02"
string(12) "57826953df77"
string(12) "c1ec83806b01"
string(12) "a50d6a523e4f"
string(12) "2597f3adf7b3"
string(12) "1f935e5cfca6"
```

And from my local PHP _(PHP 7.1.12 (cli) (built: Nov 23 2017 04:33:43) ( NTS MSVC14 (Visual C++ 2015) x86 )_. Note the leading zeros:

```
string(12) "00003e573b8b"
string(12) "0000363534d3"
string(12) "00005dd23a9a"
string(12) "0000a7788b66"
string(12) "0000af510161"
string(12) "000082e3e0af"
```