### PR TITLE
Fix for DefaultTimeGenerator

### DIFF
--- a/src/Generator/DefaultTimeGenerator.php
+++ b/src/Generator/DefaultTimeGenerator.php
@@ -79,7 +79,7 @@ class DefaultTimeGenerator implements TimeGeneratorInterface
 
         if ($clockSeq === null) {
             // Not using "stable storage"; see RFC 4122, Section 4.2.1.1
-            $clockSeq = mt_rand(0, 0x3fff);
+            $clockSeq = random_int(0, 0x3fff);
         }
 
         // Create a 60-bit time value as a count of 100-nanosecond intervals

--- a/src/Generator/DefaultTimeGenerator.php
+++ b/src/Generator/DefaultTimeGenerator.php
@@ -79,7 +79,7 @@ class DefaultTimeGenerator implements TimeGeneratorInterface
 
         if ($clockSeq === null) {
             // Not using "stable storage"; see RFC 4122, Section 4.2.1.1
-            $clockSeq = mt_rand(0, 1 << 14);
+            $clockSeq = mt_rand(0, 0x3fff);
         }
 
         // Create a 60-bit time value as a count of 100-nanosecond intervals

--- a/tests/Generator/DefaultTimeGeneratorTest.php
+++ b/tests/Generator/DefaultTimeGeneratorTest.php
@@ -173,6 +173,6 @@ class DefaultTimeGeneratorTest extends TestCase
             $this->timeProvider
         );
         $defaultTimeGenerator->generate($this->nodeId);
-        $mt_rand->verifyInvokedOnce([0, 16384]);
+        $mt_rand->verifyInvokedOnce([0, 0x3fff]);
     }
 }

--- a/tests/Generator/DefaultTimeGeneratorTest.php
+++ b/tests/Generator/DefaultTimeGeneratorTest.php
@@ -166,7 +166,7 @@ class DefaultTimeGeneratorTest extends TestCase
     public function testGenerateUsesRandomSequenceWhenClockSeqNull()
     {
         $this->skipIfHhvm();
-        $mt_rand = AspectMock::func('Ramsey\Uuid\Generator', 'mt_rand', 9622);
+        $mt_rand = AspectMock::func('Ramsey\Uuid\Generator', 'random_int', 9622);
         $defaultTimeGenerator = new DefaultTimeGenerator(
             $this->nodeProvider,
             $this->timeConverter,


### PR DESCRIPTION
An unrelated fix for an off-by-one error I spotted while studying your code. 16384 is actually the first 15-bit integer and [is out of spec](https://tools.ietf.org/html/rfc4122#section-4.2.2). I've changed the format to hexadecimal to emphasize where the bit width ends.

Also replaced `mt_rand` with `random_int`. Even though the library targets PHP 5.4 it already required `paragonie/random_compat` so it was already available for all versions below 7.0.