### PR TITLE
4.x  phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "phpunit": "phpunit --verbose --colors=always",
         "phpcs": "phpcs src tests --standard=psr2 -sp --colors",
         "phpstan": [
-            "phpstan analyse -c phpstan.neon src --level 4 --no-progress",
+            "phpstan analyse -c phpstan.neon src --level 5 --no-progress",
             "phpstan analyse -c phpstan-tests.neon tests --level 2 --no-progress"
         ],
         "test": [

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "phpunit": "phpunit --verbose --colors=always",
         "phpcs": "phpcs src tests --standard=psr2 -sp --colors",
         "phpstan": [
-            "phpstan analyse -c phpstan.neon src --level 3 --no-progress",
+            "phpstan analyse -c phpstan.neon src --level 4 --no-progress",
             "phpstan analyse -c phpstan-tests.neon tests --level 2 --no-progress"
         ],
         "test": [

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "phpcs": "phpcs src tests --standard=psr2 -sp --colors",
         "phpstan": [
             "phpstan analyse -c phpstan.neon src --level 5 --no-progress",
-            "phpstan analyse -c phpstan-tests.neon tests --level 3 --no-progress"
+            "phpstan analyse -c phpstan-tests.neon tests --level 4 --no-progress"
         ],
         "test": [
             "@lint",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "phpunit": "phpunit --verbose --colors=always",
         "phpcs": "phpcs src tests --standard=psr2 -sp --colors",
         "phpstan": [
-            "phpstan analyse -c phpstan.neon src --level 7 --no-progress",
+            "phpstan analyse -c phpstan.neon src --level max --no-progress",
             "phpstan analyse -c phpstan-tests.neon tests --level 4 --no-progress"
         ],
         "test": [

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "phpunit": "phpunit --verbose --colors=always",
         "phpcs": "phpcs src tests --standard=psr2 -sp --colors",
         "phpstan": [
-            "phpstan analyse -c phpstan.neon src --level 6 --no-progress",
+            "phpstan analyse -c phpstan.neon src --level 7 --no-progress",
             "phpstan analyse -c phpstan-tests.neon tests --level 4 --no-progress"
         ],
         "test": [

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "phpcs": "phpcs src tests --standard=psr2 -sp --colors",
         "phpstan": [
             "phpstan analyse -c phpstan.neon src --level 5 --no-progress",
-            "phpstan analyse -c phpstan-tests.neon tests --level 2 --no-progress"
+            "phpstan analyse -c phpstan-tests.neon tests --level 3 --no-progress"
         ],
         "test": [
             "@lint",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "phpunit": "phpunit --verbose --colors=always",
         "phpcs": "phpcs src tests --standard=psr2 -sp --colors",
         "phpstan": [
-            "phpstan analyse -c phpstan.neon src --level 5 --no-progress",
+            "phpstan analyse -c phpstan.neon src --level 6 --no-progress",
             "phpstan analyse -c phpstan-tests.neon tests --level 4 --no-progress"
         ],
         "test": [

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "phpunit": "phpunit --verbose --colors=always",
         "phpcs": "phpcs src tests --standard=psr2 -sp --colors",
         "phpstan": [
-            "phpstan analyse -c phpstan.neon src --level 2 --no-progress",
+            "phpstan analyse -c phpstan.neon src --level 3 --no-progress",
             "phpstan analyse -c phpstan-tests.neon tests --level 2 --no-progress"
         ],
         "test": [

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -2,6 +2,6 @@ parameters:
     ignoreErrors:
         - '#Function uuid_create not found#'
         - '#Function uuid_parse not found#'
-
         - '#Constant UUID_TYPE_TIME not found#'
         - '#Constant UUID_TYPE_RANDOM not found#'
+        - '#does not accept PHPUnit_Framework_MockObject_MockObject#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,4 @@ parameters:
         - '#Function Sodium\\randombytes_buf not found#'
         - '#Constant UUID_TYPE_TIME not found#'
         - '#Constant UUID_TYPE_RANDOM not found#'
+        - '#Moontoast\\Math\\BigNumber::convertFromBase10\(\) expects int\|string, Moontoast\\Math\\BigNumber given.#'

--- a/src/Generator/DefaultTimeGenerator.php
+++ b/src/Generator/DefaultTimeGenerator.php
@@ -85,7 +85,7 @@ class DefaultTimeGenerator implements TimeGeneratorInterface
         // Create a 60-bit time value as a count of 100-nanosecond intervals
         // since 00:00:00.00, 15 October 1582
         $timeOfDay = $this->timeProvider->currentTime();
-        $uuidTime = $this->timeConverter->calculateTime($timeOfDay['sec'], $timeOfDay['usec']);
+        $uuidTime = $this->timeConverter->calculateTime((string) $timeOfDay['sec'], (string) $timeOfDay['usec']);
 
         $timeHi = BinaryUtils::applyVersion($uuidTime['hi'], 1);
         $clockSeqHi = BinaryUtils::applyVariant($clockSeq >> 8);

--- a/src/Generator/DefaultTimeGenerator.php
+++ b/src/Generator/DefaultTimeGenerator.php
@@ -109,7 +109,7 @@ class DefaultTimeGenerator implements TimeGeneratorInterface
      * Uses the node provider given when constructing this instance to get
      * the node ID (usually a MAC address)
      *
-     * @param string|int $node A node value that may be used to override the node provider
+     * @param string|int|null $node A node value that may be used to override the node provider
      * @return string Hexadecimal representation of the node ID
      */
     protected function getValidNode($node)

--- a/src/Generator/RandomLibAdapter.php
+++ b/src/Generator/RandomLibAdapter.php
@@ -40,13 +40,13 @@ class RandomLibAdapter implements RandomGeneratorInterface
      */
     public function __construct(Generator $generator = null)
     {
-        $this->generator = $generator;
-
-        if ($this->generator === null) {
+        if ($generator === null) {
             $factory = new Factory();
 
-            $this->generator = $factory->getMediumStrengthGenerator();
+            $generator = $factory->getMediumStrengthGenerator();
         }
+
+        $this->generator = $generator;
     }
 
     /**

--- a/src/Provider/Node/FallbackNodeProvider.php
+++ b/src/Provider/Node/FallbackNodeProvider.php
@@ -42,7 +42,7 @@ class FallbackNodeProvider implements NodeProviderInterface
      * Returns the system node ID by iterating over an array of node providers
      * and returning the first non-empty value found
      *
-     * @return string System node ID as a hexadecimal string
+     * @return string|null System node ID as a hexadecimal string
      */
     public function getNode()
     {

--- a/tests/Codec/GuidStringCodecTest.php
+++ b/tests/Codec/GuidStringCodecTest.php
@@ -38,9 +38,7 @@ class GuidStringCodecTest extends TestCase
     protected function tearDown()
     {
         parent::tearDown();
-        $this->builder = null;
-        $this->fields = null;
-        $this->uuid = null;
+        unset($this->builder, $this->fields, $this->uuid);
     }
 
     public function testEncodeUsesFieldsArray()

--- a/tests/Codec/OrderedTimeCodecTest.php
+++ b/tests/Codec/OrderedTimeCodecTest.php
@@ -42,9 +42,7 @@ class OrderedTimeCodecTest extends TestCase
     protected function tearDown()
     {
         parent::tearDown();
-        $this->builder = null;
-        $this->uuid = null;
-        $this->fields = null;
+        unset($this->builder, $this->uuid, $this->fields);
     }
 
     public function testEncodeUsesFieldsArray()

--- a/tests/Codec/StringCodecTest.php
+++ b/tests/Codec/StringCodecTest.php
@@ -40,9 +40,7 @@ class StringCodecTest extends TestCase
     protected function tearDown()
     {
         parent::tearDown();
-        $this->builder = null;
-        $this->uuid = null;
-        $this->fields = null;
+        unset($this->builder, $this->uuid, $this->fields);
     }
 
     public function testEncodeUsesFieldsArray()

--- a/tests/Generator/DefaultTimeGeneratorTest.php
+++ b/tests/Generator/DefaultTimeGeneratorTest.php
@@ -41,9 +41,7 @@ class DefaultTimeGeneratorTest extends TestCase
     protected function tearDown()
     {
         parent::tearDown();
-        $this->timeProvider = null;
-        $this->nodeProvider = null;
-        $this->timeConverter = null;
+        unset($this->timeProvider, $this->nodeProvider, $this->timeConverter);
         Mockery::close();
         AspectMock::clean();
     }


### PR DESCRIPTION
* resolved #207
* switched from phpstan/phpstan-shim to phpstan/phpstan,
* adjusted the composer script to behave nicely on gitbash/travis etc.
* bumped up some of the phpstan levels, resolved issues.

a phpdoc block in moontoast/math is holding up level 6: https://github.com/ramsey/moontoast-math/blob/c2792a25df5cad4ff3d760dd37078fc5b6fccc79/src/Moontoast/Math/BigNumber.php#L633 , i.e. BigNumber is being passed in when the docs specify string|int