### PR TITLE
Improvements to the SystemNodeProviderTest class

### DIFF
--- a/src/Provider/Node/SystemNodeProvider.php
+++ b/src/Provider/Node/SystemNodeProvider.php
@@ -88,17 +88,16 @@ class SystemNodeProvider implements NodeProviderInterface
     {
         $mac = false;
 
-        if (strtoupper(php_uname('s')) === "LINUX") {
+        if (strtoupper(php_uname('s')) === 'LINUX') {
             $addressPaths = glob('/sys/class/net/*/address', GLOB_NOSORT);
 
             if (empty($addressPaths)) {
                 return false;
             }
 
-            $macs = array_map(
-                'file_get_contents',
-                $addressPaths
-            );
+            array_walk($addressPaths, function ($addressPath) use (&$macs) {
+                $macs[] = file_get_contents($addressPath);
+            });
 
             $macs = array_map('trim', $macs);
 

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -58,7 +58,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () use ($netstatOutput) {echo $netstatOutput;},
+            function () use ($netstatOutput) {
+                echo $netstatOutput;
+            },
             'NOT LINUX'
         );
 
@@ -92,7 +94,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () use ($netstatOutput) {echo $netstatOutput;},
+            function () use ($netstatOutput) {
+                echo $netstatOutput;
+            },
             'NOT LINUX'
         );
 
@@ -121,7 +125,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () use ($formatted) {echo "\n{$formatted}\n";},
+            function () use ($formatted) {
+                echo "\n{$formatted}\n";
+            },
             'NOT LINUX'
         );
 
@@ -149,7 +155,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () use ($formatted) {echo "\n{$formatted}\n";},
+            function () use ($formatted) {
+                echo "\n{$formatted}\n";
+            },
             'NOT LINUX'
         );
 
@@ -199,7 +207,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () {echo 'some string that does not match the mac address';},
+            function () {
+                echo 'some string that does not match the mac address';
+            },
             'NOT LINUX'
         );
 
@@ -223,7 +233,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () {echo 'some string that does not match the mac address';},
+            function () {
+                echo 'some string that does not match the mac address';
+            },
             'NOT LINUX'
         );
 
@@ -282,7 +294,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () {echo "\nAA-BB-CC-DD-EE-FF\n";},
+            function () {
+                echo "\nAA-BB-CC-DD-EE-FF\n";
+            },
             'NOT LINUX'
         );
 
@@ -307,7 +321,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () {echo "\nAA-BB-CC-DD-EE-FF\n";},
+            function () {
+                echo "\nAA-BB-CC-DD-EE-FF\n";
+            },
             'NOT LINUX'
         );
 
@@ -340,7 +356,9 @@ class SystemNodeProviderTest extends TestCase
                 return array_shift($macs);
             },
             ['mock address path 1', 'mock address path 2'],
-            function () {echo "\n01-02-03-04-05-06\n";},
+            function () {
+                echo "\n01-02-03-04-05-06\n";
+            },
             $os
         );
 
@@ -375,7 +393,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             false,
-            function () {echo "\n01-02-03-04-05-06\n";},
+            function () {
+                echo "\n01-02-03-04-05-06\n";
+            },
             'Linux'
         );
 
@@ -399,7 +419,9 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             [],
-            function () {echo "\n01-02-03-04-05-06\n";},
+            function () {
+                echo "\n01-02-03-04-05-06\n";
+            },
             'Linux'
         );
 
@@ -454,14 +476,14 @@ class SystemNodeProviderTest extends TestCase
             self::MOCK_UNAME => $unameBodyAssert,
         ];
 
-        array_walk($mockFunctionAsserts,  function ($asserts, $key) {
+        array_walk($mockFunctionAsserts, function ($asserts, $key) {
             if ($asserts === null) {
                 $this->functionProxies[$key]->verifyNeverInvoked();
-            } elseif(is_array($asserts)) {
+            } elseif (is_array($asserts)) {
                 foreach ($asserts as $assert) {
                     $this->functionProxies[$key]->verifyInvokedOnce($assert);
                 }
-            } elseif(is_callable($asserts)) {
+            } elseif (is_callable($asserts)) {
                 $this->functionProxies[$key]->verifyInvokedOnce($asserts);
             } else {
                 $error = vsprintf(
@@ -497,7 +519,10 @@ class SystemNodeProviderTest extends TestCase
     public function provideInvalidNetStatOutput()
     {
         return [
-            'Not an octal value'                              => ["The program 'netstat' is currently not installed. You can install it by typing:\nsudo apt install net-tools\n"],
+            'Not an octal value'                              => [
+                "The program 'netstat' is currently not installed.' .
+                ' You can install it by typing:\nsudo apt install net-tools\n"
+            ],
             'One character too short'                         => ["\nA-BB-CC-DD-EE-FF\n"],
             'One tuple too short'                             => ["\nBB-CC-DD-EE-FF\n"],
             'With colon, with linebreak, without space'       => ["\n:AA-BB-CC-DD-EE-FF\n"],

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -418,35 +418,6 @@ class SystemNodeProviderTest extends TestCase
     }
 
     /**
-     * Provides mac addresses that the class under test should strip notational format from
-     *
-     * @return array[]
-     */
-    public function provideNotationalFormats()
-    {
-        return [
-            ['01-23-45-67-89-ab', '0123456789ab'],
-            ['01:23:45:67:89:ab', '0123456789ab']
-        ];
-    }
-
-    /**
-     * Provides the command that should be executed per supported OS
-     *
-     * @return array[]
-     */
-    public function provideCommandPerOs()
-    {
-        return [
-            'windows' => ['Windows', 'ipconfig /all 2>&1'],
-            'mac' => ['Darwhat', 'ifconfig 2>&1'],
-            'linux' => ['Linux', 'netstat -ie 2>&1'],
-            'anything_else' => ['someotherxyz', 'netstat -ie 2>&1'],
-            'Linux when `glob` fails' => ['LIN', 'netstat -ie 2>&1'],
-        ];
-    }
-
-    /**
      * Replaces the return value for functions with the given value or callback.
      *
      * @param callback|mixed|null $fileGetContentsBody
@@ -504,6 +475,76 @@ class SystemNodeProviderTest extends TestCase
                 throw new \InvalidArgumentException($error);
             }
         });
+    }
+
+    /**
+     * Provides the command that should be executed per supported OS
+     *
+     * @return array[]
+     */
+    public function provideCommandPerOs()
+    {
+        return [
+            'windows' => ['Windows', 'ipconfig /all 2>&1'],
+            'mac' => ['Darwhat', 'ifconfig 2>&1'],
+            'linux' => ['Linux', 'netstat -ie 2>&1'],
+            'anything_else' => ['someotherxyz', 'netstat -ie 2>&1'],
+            'Linux when `glob` fails' => ['LIN', 'netstat -ie 2>&1'],
+        ];
+    }
+
+    /**
+     * Values that are NOT parsed to a mac address by the class under test
+     *
+     * @return array[]
+     */
+    public function provideInvalidNetStatOutput()
+    {
+        return [
+            'Not an octal value'                              => ["The program 'netstat' is currently not installed. You can install it by typing:\nsudo apt install net-tools\n"],
+            'One character too short'                         => ["\nA-BB-CC-DD-EE-FF\n"],
+            'One tuple too short'                             => ["\nBB-CC-DD-EE-FF\n"],
+            'With colon, with linebreak, without space'       => ["\n:AA-BB-CC-DD-EE-FF\n"],
+            'With colon, without linebreak, with space'       => [' : AA-BB-CC-DD-EE-FF'],
+            'With colon, without linebreak, without space'    => [':AA-BB-CC-DD-EE-FF'],
+            'Without colon, without linebreak, without space' => ['AA-BB-CC-DD-EE-FF'],
+            'Without leading linebreak'                       => ["AA-BB-CC-DD-EE-FF\n"],
+            'Without leading whitespace'                      => ['AA-BB-CC-DD-EE-FF '],
+            'Without trailing linebreak'                      => ["\nAA-BB-CC-DD-EE-FF"],
+            'Without trailing whitespace'                     => [' AA-BB-CC-DD-EE-FF'],
+        ];
+    }
+
+    /**
+     * Provides notations that the class under test should NOT attempt to strip
+     *
+     * @return array[]
+     */
+    public function provideInvalidNotationalFormats()
+    {
+        return [
+            ['01:23-45-67-89-ab'],
+            ['01:23:45-67-89-ab'],
+            ['01:23:45:67-89-ab'],
+            ['01:23:45:67:89-ab'],
+            ['01-23:45:67:89:ab'],
+            ['01-23-45:67:89:ab'],
+            ['01-23-45-67:89:ab'],
+            ['01-23-45-67-89:ab'],
+        ];
+    }
+
+    /**
+     * Provides mac addresses that the class under test should strip notational format from
+     *
+     * @return array[]
+     */
+    public function provideNotationalFormats()
+    {
+        return [
+            ['01-23-45-67-89-ab', '0123456789ab'],
+            ['01:23:45:67:89:ab', '0123456789ab']
+        ];
     }
 
     /**
@@ -671,47 +712,6 @@ TXT
             'Local host'                   => ["\n00:00:00:00:00:00\n",    '000000000000'],
             'Too long -- extra character'  => ["\nAAA-BB-CC-DD-EE-FF\n",   'AABBCCDDEEFF'],
             'Too long -- extra tuple'      => ["\n01-AA-BB-CC-DD-EE-FF\n", '01AABBCCDDEE'],
-        ];
-    }
-
-    /**
-     * Values that are NOT parsed to a mac address by the class under test
-     *
-     * @return array[]
-     */
-    public function provideInvalidNetStatOutput()
-    {
-        return [
-            'Not an octal value'                              => ["The program 'netstat' is currently not installed. You can install it by typing:\nsudo apt install net-tools\n"],
-            'One character too short'                         => ["\nA-BB-CC-DD-EE-FF\n"],
-            'One tuple too short'                             => ["\nBB-CC-DD-EE-FF\n"],
-            'With colon, with linebreak, without space'       => ["\n:AA-BB-CC-DD-EE-FF\n"],
-            'With colon, without linebreak, with space'       => [' : AA-BB-CC-DD-EE-FF'],
-            'With colon, without linebreak, without space'    => [':AA-BB-CC-DD-EE-FF'],
-            'Without colon, without linebreak, without space' => ['AA-BB-CC-DD-EE-FF'],
-            'Without leading linebreak'                       => ["AA-BB-CC-DD-EE-FF\n"],
-            'Without leading whitespace'                      => ['AA-BB-CC-DD-EE-FF '],
-            'Without trailing linebreak'                      => ["\nAA-BB-CC-DD-EE-FF"],
-            'Without trailing whitespace'                     => [' AA-BB-CC-DD-EE-FF'],
-        ];
-    }
-
-    /**
-     * Provides notations that the class under test should NOT attempt to strip
-     *
-     * @return array[]
-     */
-    public function provideInvalidNotationalFormats()
-    {
-        return [
-            ['01:23-45-67-89-ab'],
-            ['01:23:45-67-89-ab'],
-            ['01:23:45:67-89-ab'],
-            ['01:23:45:67:89-ab'],
-            ['01-23:45:67:89:ab'],
-            ['01-23-45:67:89:ab'],
-            ['01-23-45-67:89:ab'],
-            ['01-23-45-67-89:ab'],
         ];
     }
 }

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -88,26 +88,22 @@ class SystemNodeProviderTest extends TestCase
      */
     public function testGetNodeShouldNotReturnsSystemNodeForInvalidMacAddress($netstatOutput)
     {
-        /*/ Arrange mocks for native functions /*/
-        $mockFileGetContents = AspectMock::func(self::PROVIDER_NAMESPACE, self::MOCK_FILE_GET_CONTENTS, null);
-        $mockGlob = AspectMock::func(self::PROVIDER_NAMESPACE, self::MOCK_GLOB, null);
-        $mockPassthru = AspectMock::func(self::PROVIDER_NAMESPACE, self::MOCK_PASSTHRU, function () use ($netstatOutput) {
-            echo $netstatOutput;
-        });
-        $mockUname = AspectMock::func(self::PROVIDER_NAMESPACE, self::MOCK_UNAME, 'NOT LINUX');
+        /*/ Arrange /*/
+        $this->arrangeMockFunctions(
+            null,
+            null,
+            function () use ($netstatOutput) {echo $netstatOutput;},
+            'NOT LINUX'
+        );
 
-        /*/ Act upon the system under test/*/
+        /*/ Act /*/
         $provider = new SystemNodeProvider();
-        $actual = $provider->getNode();
+        $node = $provider->getNode();
 
-        /*/ Assert the result match expectations /*/
-        $mockFileGetContents->verifyNeverInvoked();
-        $mockGlob->verifyNeverInvoked();
-        $mockPassthru->verifyInvokedOnce('netstat -ie 2>&1');
-        $mockUname->verifyInvokedOnce(['s']);
-        $mockUname->verifyInvokedOnce(['a']);
+        /*/ Assert /*/
+        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], [['a'], ['s']]);
 
-        $this->assertFalse($actual);
+        $this->assertFalse($node);
     }
 
     /**

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -51,14 +51,19 @@ class SystemNodeProviderTest extends TestCase
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
+     *
+     * @dataProvider provideValidNetStatOutput
+     *
+     * @param $netstatOutput
+     * @param $expected
      */
-    public function testGetNodeReturnsSystemNodeFromMacAddress()
+    public function testGetNodeReturnsSystemNodeFromMacAddress($netstatOutput, $expected)
     {
         /*/ Arrange mocks for native functions /*/
         $this->arrangeMockFunctions(
             null,
             null,
-            function () {echo "\nAA-BB-CC-DD-EE-FF\n";},
+            function () use ($netstatOutput) {echo $netstatOutput;},
             'NOT LINUX'
         );
 
@@ -69,12 +74,13 @@ class SystemNodeProviderTest extends TestCase
         /*/ Assert the result match expectations /*/
         $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], [['a'], ['s']]);
 
-        $this->assertSame('AABBCCDDEEFF', $node);
+        $this->assertSame($expected, $node);
 
-        $this->assertTrue(ctype_xdigit($node), 'Node should be a hexadecimal string. Actual node: ' . $node);
-        $length = strlen($node);
-        $lengthError = 'Node should be 12 characters. Actual length: ' . $length . PHP_EOL . ' Actual node: ' . $node;
-        $this->assertSame(12, $length, $lengthError);
+        $message = vsprintf(
+            'Node should be a hexadecimal string of 12 characters. Actual node: %s (length: %s)',
+            [$node, strlen($node),]
+        );
+        $this->assertRegExp('/^[A-Fa-f0-9]{12}$/', $node, $message);
     }
 
     /**
@@ -432,5 +438,173 @@ class SystemNodeProviderTest extends TestCase
                 throw new \InvalidArgumentException($error);
             }
         });
+    }
+
+    /**
+     * Values that are parsed to a mac address by the class under test
+     *
+     * @return array[]
+     */
+    public function provideValidNetStatOutput()
+    {
+        return [
+            /*/ Full output of related command /*/
+            'Full output - Linux' => [<<<'TXT'
+                Kernel Interface table
+                docker0   Link encap:Ethernet  HWaddr 01:23:45:67:89:ab  
+                          inet addr:172.17.0.1  Bcast:0.0.0.0  Mask:255.255.0.0
+                          UP BROADCAST MULTICAST  MTU:1500  Metric:1
+                          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
+                          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
+                          collisions:0 txqueuelen:0 
+                          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
+                
+                enp3s0    Link encap:Ethernet  HWaddr fe:dc:ba:98:76:54  
+                          inet addr:10.0.0.1  Bcast:10.0.0.255  Mask:255.255.255.0
+                          inet6 addr: ffee::ddcc:bbaa:9988:7766/64 Scope:Link
+                          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+                          RX packets:943077 errors:0 dropped:0 overruns:0 frame:0
+                          TX packets:2168039 errors:0 dropped:0 overruns:0 carrier:0
+                          collisions:0 txqueuelen:1000 
+                          RX bytes:748596414 (748.5 MB)  TX bytes:2930448282 (2.9 GB)
+                
+                lo        Link encap:Local Loopback  
+                          inet addr:127.0.0.1  Mask:255.0.0.0
+                          inet6 addr: ::1/128 Scope:Host
+                          UP LOOPBACK RUNNING  MTU:65536  Metric:1
+                          RX packets:8302 errors:0 dropped:0 overruns:0 frame:0
+                          TX packets:8302 errors:0 dropped:0 overruns:0 carrier:0
+                          collisions:0 txqueuelen:1000 
+                          RX bytes:1094983 (1.0 MB)  TX bytes:1094983 (1.0 MB)
+TXT
+                , '0123456789ab'],
+            'Full output - MacOS' => [<<<'TXT'
+                lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+                    options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
+                    inet 127.0.0.1 netmask 0xff000000 
+                    inet6 ::1 prefixlen 128 
+                    inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1 
+                    nd6 options=201<PERFORMNUD,DAD>
+                gif0: flags=8010<POINTOPOINT,MULTICAST> mtu 1280
+                stf0: flags=0<> mtu 1280
+                EHC29: flags=0<> mtu 0
+                XHC20: flags=0<> mtu 0
+                EHC26: flags=0<> mtu 0
+                en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+                    options=10b<RXCSUM,TXCSUM,VLAN_HWTAGGING,AV>
+                    ether 10:dd:b1:b4:e4:8e 
+                    inet6 fe80::c70:76f5:aa1:5db1%en0 prefixlen 64 secured scopeid 0x7 
+                    inet 10.53.8.112 netmask 0xfffffc00 broadcast 10.53.11.255
+                    nd6 options=201<PERFORMNUD,DAD>
+                    media: autoselect (1000baseT <full-duplex>)
+                    status: active
+                en1: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+                    ether ec:35:86:38:c8:c2 
+                    inet6 fe80::aa:d44f:5f5f:7fd4%en1 prefixlen 64 secured scopeid 0x8 
+                    inet 10.53.17.196 netmask 0xfffffc00 broadcast 10.53.19.255
+                    nd6 options=201<PERFORMNUD,DAD>
+                    media: autoselect
+                    status: active
+                p2p0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 2304
+                    ether 0e:35:86:38:c8:c2 
+                    media: autoselect
+                    status: inactive
+                awdl0: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1484
+                    ether ea:ab:ae:25:f5:d0 
+                    inet6 fe80::e8ab:aeff:fe25:f5d0%awdl0 prefixlen 64 scopeid 0xa 
+                    nd6 options=201<PERFORMNUD,DAD>
+                    media: autoselect
+                    status: active
+                en2: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
+                    options=60<TSO4,TSO6>
+                    ether 32:00:18:9b:dc:60 
+                    media: autoselect <full-duplex>
+                    status: inactive
+                en3: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
+                    options=60<TSO4,TSO6>
+                    ether 32:00:18:9b:dc:61 
+                    media: autoselect <full-duplex>
+                    status: inactive
+                bridge0: flags=8822<BROADCAST,SMART,SIMPLEX,MULTICAST> mtu 1500
+                    options=63<RXCSUM,TXCSUM,TSO4,TSO6>
+                    ether 32:00:18:9b:dc:60 
+                    Configuration:
+                        id 0:0:0:0:0:0 priority 0 hellotime 0 fwddelay 0
+                        maxage 0 holdcnt 0 proto stp maxaddr 100 timeout 1200
+                        root id 0:0:0:0:0:0 priority 0 ifcost 0 port 0
+                        ipfilter disabled flags 0x2
+                    member: en2 flags=3<LEARNING,DISCOVER>
+                            ifmaxaddr 0 port 11 priority 0 path cost 0
+                    member: en3 flags=3<LEARNING,DISCOVER>
+                            ifmaxaddr 0 port 12 priority 0 path cost 0
+                    media: <unknown type>
+                    status: inactive
+                utun0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 2000
+                    options=6403<RXCSUM,TXCSUM,CHANNEL_IO,PARTIAL_CSUM,ZEROINVERT_CSUM>
+                    inet6 fe80::57c6:d692:9d41:d28f%utun0 prefixlen 64 scopeid 0xe 
+                    nd6 options=201<PERFORMNUD,DAD>
+TXT
+                , '10ddb1b4e48e'],
+            'Full output - Window' => [<<<'TXT'
+                Windows IP Configuration
+                
+                   Host Name . . . . . . . . . . . . : MSEDGEWIN10
+                   Primary Dns Suffix  . . . . . . . : 
+                   Node Type . . . . . . . . . . . . : Hybrid
+                   IP Routing Enabled. . . . . . . . : No
+                   WINS Proxy Enabled. . . . . . . . : No
+                   DNS Suffix Search List. . . . . . : network.lan
+                
+                Ethernet adapter Ethernet:
+                
+                   Connection-specific DNS Suffix  . : network.lan
+                   Description . . . . . . . . . . . : Intel(R) PRO/1000 MT Desktop Adapter
+                   Physical Address. . . . . . . . . : 08-00-27-B8-42-C6
+                   DHCP Enabled. . . . . . . . . . . : Yes
+                   Autoconfiguration Enabled . . . . : Yes
+                   Link-local IPv6 Address . . . . . : fe80::606a:ae33:7ce1:b5e9%3(Preferred) 
+                   IPv4 Address. . . . . . . . . . . : 10.0.2.15(Preferred) 
+                   Subnet Mask . . . . . . . . . . . : 255.255.255.0
+                   Lease Obtained. . . . . . . . . . : Tuesday, January 30, 2018 11:25:31 PM
+                   Lease Expires . . . . . . . . . . : Wednesday, January 31, 2018 11:25:27 PM
+                   Default Gateway . . . . . . . . . : 10.0.2.2
+                   DHCP Server . . . . . . . . . . . : 10.0.2.2
+                   DHCPv6 IAID . . . . . . . . . . . : 34078759
+                   DHCPv6 Client DUID. . . . . . . . : 00-01-00-01-21-40-72-3F-08-00-27-B8-42-C6
+                   DNS Servers . . . . . . . . . . . : 10.0.2.3
+                   NetBIOS over Tcpip. . . . . . . . : Enabled
+                
+                Tunnel adapter isatap.network.lan:
+                
+                   Media State . . . . . . . . . . . : Media disconnected
+                   Connection-specific DNS Suffix  . : network.lan
+                   Description . . . . . . . . . . . : Microsoft ISATAP Adapter
+                   Physical Address. . . . . . . . . : 00-00-00-00-00-00-00-E0
+                   DHCP Enabled. . . . . . . . . . . : No
+                   Autoconfiguration Enabled . . . . : Yes
+TXT
+                , '080027B842C6'],
+
+            /*/ The single line that is relevant /*/
+            'Linux  - single line'  => ["\ndocker0   Link encap:Ethernet  HWaddr 01:23:45:67:89:ab\n", '0123456789ab'],
+            'MacOS  - Single line ' => ["\nether 10:dd:b1:b4:e4:8e\n", '10ddb1b4e48e'],
+            'Window - single line' => ["\nPhysical Address. . . . . . . . . : 08-00-27-B8-42-C6\n", '080027B842C6'],
+
+            /*/ Minimal subsets of the single line to show the differences /*/
+            'with colon, with linebreak, with space'          => ["\n : AA-BB-CC-DD-EE-FF\n", 'AABBCCDDEEFF'],
+            'without colon, with linebreak, with space'       => ["\n AA-BB-CC-DD-EE-FF \n",  'AABBCCDDEEFF'],
+            'without colon, with linebreak, without space'    => ["\nAA-BB-CC-DD-EE-FF\n",    'AABBCCDDEEFF'],
+            'without colon, without linebreak, with space'    => [' AA-BB-CC-DD-EE-FF ',      'AABBCCDDEEFF'],
+
+            /*/ Other accepted variations /*/
+            'Actual mac - 1'               => ["\n52:54:00:14:91:69\n",    '525400149169'],
+            'Actual mac - 2'               => ["\n00:16:3e:a9:73:f0\n",    '00163ea973f0'],
+            'FF:FF:FF:FF:FF:FF'            => ["\nFF:FF:FF:FF:FF:FF\n",    'FFFFFFFFFFFF'],
+
+            /*/ Incorrect variations that are also accepted /*/
+            'Local host'                   => ["\n00:00:00:00:00:00\n",    '000000000000'],
+            'Too long -- extra character'  => ["\nAAA-BB-CC-DD-EE-FF\n",   'AABBCCDDEEFF'],
+            'Too long -- extra tuple'      => ["\n01-AA-BB-CC-DD-EE-FF\n", '01AABBCCDDEE'],
+        ];
     }
 }

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -352,7 +352,7 @@ class SystemNodeProviderTest extends TestCase
         /*/ Arrange /*/
         $this->arrangeMockFunctions(
             function () {
-                static $macs = ["\n00:00:00:00:00:00\n", "\n01:02:03:04:05:06\n"];
+                static $macs = ["00:00:00:00:00:00\n", "01:02:03:04:05:06\n"];
                 return array_shift($macs);
             },
             ['mock address path 1', 'mock address path 2'],
@@ -731,7 +731,7 @@ TXT
 
             /*/ Incorrect variations that are also accepted /*/
             'Local host'                   => ["\n00:00:00:00:00:00\n",    '000000000000'],
-            'Too long -- extra character'  => ["\nAAA-BB-CC-DD-EE-FF\n",   'AABBCCDDEEFF'],
+            'Too long -- extra character'  => ["\nABC-01-23-45-67-89\n",   'BC0123456789'],
             'Too long -- extra tuple'      => ["\n01-AA-BB-CC-DD-EE-FF\n", '01AABBCCDDEE'],
         ];
     }

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -376,7 +376,8 @@ class SystemNodeProviderTest extends TestCase
             'windows' => ['Windows', 'ipconfig /all 2>&1'],
             'mac' => ['Darwhat', 'ifconfig 2>&1'],
             'linux' => ['Linux', 'netstat -ie 2>&1'],
-            'anything_else' => ['someotherxyz', 'netstat -ie 2>&1']
+            'anything_else' => ['someotherxyz', 'netstat -ie 2>&1'],
+            'Linux when `glob` fails' => ['LIN', 'netstat -ie 2>&1'],
         ];
     }
 

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -34,15 +34,6 @@ class SystemNodeProviderTest extends TestCase
         $this->assertSame(12, $length, $lengthError);
     }
 
-
-    public function notationalFormatsDataProvider()
-    {
-        return [
-            ['01-23-45-67-89-ab', '0123456789ab'],
-            ['01:23:45:67:89:ab', '0123456789ab']
-        ];
-    }
-
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
@@ -132,16 +123,6 @@ class SystemNodeProviderTest extends TestCase
 
         $provider->getNode();
         $provider->getNode();
-    }
-
-    public function osCommandDataProvider()
-    {
-        return [
-            'windows' => ['Windows', 'ipconfig /all 2>&1'],
-            'mac' => ['Darwhat', 'ifconfig 2>&1'],
-            'linux' => ['Linux', 'netstat -ie 2>&1'],
-            'anything_else' => ['someotherxyz', 'netstat -ie 2>&1']
-        ];
     }
 
     /**
@@ -273,5 +254,23 @@ class SystemNodeProviderTest extends TestCase
         $provider->shouldReceive('getIfconfig')->once()->andReturn(PHP_EOL . '01-02-03-04-05-06' . PHP_EOL);
 
         $this->assertEquals('010203040506', $provider->getNode());
+    }
+
+    public function notationalFormatsDataProvider()
+    {
+        return [
+            ['01-23-45-67-89-ab', '0123456789ab'],
+            ['01:23:45:67:89:ab', '0123456789ab']
+        ];
+    }
+
+    public function osCommandDataProvider()
+    {
+        return [
+            'windows' => ['Windows', 'ipconfig /all 2>&1'],
+            'mac' => ['Darwhat', 'ifconfig 2>&1'],
+            'linux' => ['Linux', 'netstat -ie 2>&1'],
+            'anything_else' => ['someotherxyz', 'netstat -ie 2>&1']
+        ];
     }
 }

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -58,7 +58,7 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () {echo PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL;},
+            function () {echo "\nAA-BB-CC-DD-EE-FF\n";},
             'NOT LINUX'
         );
 
@@ -92,7 +92,7 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () use ($formatted) {echo PHP_EOL . $formatted . PHP_EOL;},
+            function () use ($formatted) {echo "\n{$formatted}\n";},
             'NOT LINUX'
         );
 
@@ -117,10 +117,7 @@ class SystemNodeProviderTest extends TestCase
             null,
             null,
             function () {
-                echo PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL .
-                    '00-11-22-33-44-55' . PHP_EOL .
-                    'FF-11-EE-22-DD-33' . PHP_EOL
-                ;
+                echo "\nAA-BB-CC-DD-EE-FF\n00-11-22-33-44-55\nFF-11-EE-22-DD-33\n";
             },
             'NOT LINUX'
         );
@@ -228,7 +225,7 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () {echo PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL;},
+            function () {echo "\nAA-BB-CC-DD-EE-FF\n";},
             'NOT LINUX'
         );
 
@@ -253,7 +250,7 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             null,
-            function () {echo PHP_EOL . 'AA-BB-CC-DD-EE-FF' . PHP_EOL;},
+            function () {echo "\nAA-BB-CC-DD-EE-FF\n";},
             'NOT LINUX'
         );
 
@@ -286,7 +283,7 @@ class SystemNodeProviderTest extends TestCase
                 return array_shift($macs);
             },
             ['mock address path 1', 'mock address path 2'],
-            function () {echo PHP_EOL . '01-02-03-04-05-06' . PHP_EOL;},
+            function () {echo "\n01-02-03-04-05-06\n";},
             $os
         );
 
@@ -321,7 +318,7 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             false,
-            function () {echo PHP_EOL . '01-02-03-04-05-06' . PHP_EOL;},
+            function () {echo "\n01-02-03-04-05-06\n";},
             'Linux'
         );
 
@@ -345,7 +342,7 @@ class SystemNodeProviderTest extends TestCase
         $this->arrangeMockFunctions(
             null,
             [],
-            function () {echo PHP_EOL . '01-02-03-04-05-06' . PHP_EOL;},
+            function () {echo "\n01-02-03-04-05-06\n";},
             'Linux'
         );
 

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -30,11 +30,6 @@ use AspectMock\Test as AspectMock;
  * should be run should ALWAYS be specified.
  *
  * This will make the tests more verbose but also more bullet-proof.
- *
- * This class mostly tests happy-path (success scenario) and leaves various
- * sad-path (failure scenarios) untested.
- *
- * @TODO: Add tests for failure scenario's
  */
 class SystemNodeProviderTest extends TestCase
 {
@@ -119,7 +114,7 @@ class SystemNodeProviderTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      *
-     * @dataProvider notationalFormatsDataProvider
+     * @dataProvider provideNotationalFormats
      *
      * @param string $formatted
      * @param string $expected
@@ -148,7 +143,7 @@ class SystemNodeProviderTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      *
-     * @dataProvider invalidNotationalFormatsDataProvider
+     * @dataProvider provideInvalidNotationalFormats
      *
      * @param string $formatted
      */
@@ -249,7 +244,7 @@ class SystemNodeProviderTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      *
-     * @dataProvider osCommandDataProvider
+     * @dataProvider provideCommandPerOs
      *
      * @param $os
      * @param $command
@@ -335,7 +330,7 @@ class SystemNodeProviderTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      *
-     * @dataProvider osCommandDataProvider
+     * @dataProvider provideCommandPerOs
      *
      * @param $os
      * @param $command
@@ -422,7 +417,12 @@ class SystemNodeProviderTest extends TestCase
         $this->assertEquals('010203040506', $node);
     }
 
-    public function notationalFormatsDataProvider()
+    /**
+     * Provides mac addresses that the class under test should strip notational format from
+     *
+     * @return array[]
+     */
+    public function provideNotationalFormats()
     {
         return [
             ['01-23-45-67-89-ab', '0123456789ab'],
@@ -430,7 +430,12 @@ class SystemNodeProviderTest extends TestCase
         ];
     }
 
-    public function osCommandDataProvider()
+    /**
+     * Provides the command that should be executed per supported OS
+     *
+     * @return array[]
+     */
+    public function provideCommandPerOs()
     {
         return [
             'windows' => ['Windows', 'ipconfig /all 2>&1'],
@@ -696,7 +701,7 @@ TXT
      *
      * @return array[]
      */
-    public function invalidNotationalFormatsDataProvider()
+    public function provideInvalidNotationalFormats()
     {
         return [
             ['01:23-45-67-89-ab'],


### PR DESCRIPTION
As stated in [the accompanying issue](https://github.com/ramsey/uuid/issues/187), the tests for the SystemNodeProvider class suffer from the "Subclass To Test" anti-pattern by mocking the class under test.

This merge request fixes that.

Besides a minor change in the class itself, this MR focuses exclusively on the test:

- The class under test is no longer mocked, instead the native PHP functions are mocked (using the already present AspectMock).
- Documentation is added to the test class to make it's purpose more clear.
- The main test case has been expanded with a data-provider that offers more descriptive examples of the input the class under test is expected to parse.
- Two new classes (and data-providers) have been added for negative scenario's.
- The methods in the test class have been grouped so that the test functions, the mock functions and the data-provides are grouped together.

It is possible that certain test scenarios are present twice because it was not entirely clear to me what each test was trying to accomplish as the test name where somewhat lacking a descriptive quality.

The recent division of logic for a Linux specific approach has also created duplication. If so desired I could make an attempt to de-duplicate the tests.

For now, this is what I've got, feedback welcome.