### PR TITLE
Add support for determining MAC address on FreeBSD systems

### DIFF
--- a/src/Provider/Node/SystemNodeProvider.php
+++ b/src/Provider/Node/SystemNodeProvider.php
@@ -70,6 +70,9 @@ class SystemNodeProvider implements NodeProviderInterface
             case 'DAR':
                 passthru('ifconfig 2>&1');
                 break;
+            case 'FRE':
+                passthru('netstat -i -f link 2>&1');
+                break;
             case 'LIN':
             default:
                 passthru('netstat -ie 2>&1');

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -140,6 +140,7 @@ class SystemNodeProviderTest extends TestCase
             'windows' => ['Windows', 'ipconfig /all 2>&1'],
             'mac' => ['Darwhat', 'ifconfig 2>&1'],
             'linux' => ['Linux', 'netstat -ie 2>&1'],
+            'freebsd' => ['FreeBSD', 'netstat -i -f link 2>&1'],
             'anything_else' => ['someotherxyz', 'netstat -ie 2>&1']
         ];
     }


### PR DESCRIPTION
## Background
I noticed that the system node part of the UUID was always random on our FreeBSD systems.  After reviewing the code I see that `SystemNodeProvider` uses the output of `php_uname` to determine the OS it's running on.

It doesn't specifically test for FreeBSD, and the default uses a `netstat` command that isn't supported on FreeBSD.

## Solution
I have updated `SystemNodeProvider` to check for FreeBSD specifically and have included a `net stat` command that will provide output such as the following:

```
Name    Mtu Network       Address              Ipkts Ierrs Idrop    Opkts Oerrs  Coll
em0    1500 <Link#1>      08:00:27:71:a1:00    65514     0     0    42918     0     0
em1    1500 <Link#2>      08:00:27:d0:60:a0     1199     0     0      535     0     0
lo0   16384 <Link#3>      lo0                      4     0     0        4     0     0
```

This should be compatible with the current `netstat`/`ifconfig` output parser.

I have also updated `SystemNodeProviderTest` with the new system.