### PR TITLE
Tests: configure cacheDir for AspectMock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-gmp": "*",
         "codeception/aspect-mock": "~2.0.0",
         "doctrine/annotations": "^1.2",
-        "goaop/framework": "^2.1 <2.2",
+        "goaop/framework": "^2.1",
         "ircmaxell/random-lib": "^1.1",
         "jakub-onderka/php-parallel-lint": "^0.9.0",
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-gmp": "*",
         "codeception/aspect-mock": "~2.0.0",
         "doctrine/annotations": "^1.2",
-        "goaop/framework": "^2.1",
+        "goaop/framework": "^2.1 <2.2",
         "ircmaxell/random-lib": "^1.1",
         "jakub-onderka/php-parallel-lint": "^0.9.0",
         "mockery/mockery": "^1.0",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,5 +30,6 @@ if (!defined('UUID_TYPE_RANDOM')) {
 $kernel = \AspectMock\Kernel::getInstance();
 $kernel->init([
     'debug' => true,
+    'cacheDir' => sys_get_temp_dir(),
     'includePaths' => [__DIR__ . '/../src']
 ]);


### PR DESCRIPTION
Broken because of new version of [goaop/framework was released](https://github.com/goaop/framework/releases).

Ref https://github.com/ramsey/uuid/pull/210#discussion_r168399987

EDIT: Depends on https://github.com/ramsey/uuid/pull/214