### PR TITLE
Add a polyfill for ctype

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "require": {
         "php": "^5.4 || ^7.0",
-        "paragonie/random_compat": "^1.0|^2.0"
+        "paragonie/random_compat": "^1.0|^2.0",
+        "backendtea/ctype-compat": "^0.1.0"
     },
     "require-dev": {
         "moontoast/math": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^5.4 || ^7.0",
         "paragonie/random_compat": "^1.0|^2.0",
-        "backendtea/ctype-compat": "^0.1.0"
+        "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {
         "moontoast/math": "^1.1",


### PR DESCRIPTION
This deals with #142 by adding a polyfil for the ctype functions instead of failing an install.

The only downside for end users is that their version is slightly slower if it is ran without ctype. But it does allow them to run it, instead of  not allowing the composer install.

I can understand not wanting to add a new dependency to the project, especially if it is only to support one edge-case on one function.

I can also add the following snippet to this project instead, since xdigit is the only ctype function in use.
```php
    if(!function_exists('ctype_xdigit')) {
        /**
         * Returns TRUE if every character in text is a hexadecimal 'digit', that is a decimal digit or a character from [A-Fa-f] , FALSE otherwise.
         *
         * @see http://php.net/manual/en/function.ctype-xdigit.php
         *
         * @param string|int $text
         *
         * @return bool
         */
        function ctype_xdigit($text)
        {
            $text = conver_int_to_char_for_ctype($text);
            return !empty($text) && !preg_match('/[^A-Fa-f0-9]/', $text);
        }
    }
```