### PR TITLE
Don't allow UUIDs to have trailing newline

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -654,7 +654,7 @@ class Uuid implements UuidInterface
             return true;
         }
 
-        if (!preg_match('/' . self::VALID_PATTERN . '/', $uuid)) {
+        if (!preg_match('/' . self::VALID_PATTERN . '/D', $uuid)) {
             return false;
         }
 

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -89,6 +89,15 @@ class UuidTest extends TestCase
     }
 
     /**
+     * @expectedException \Ramsey\Uuid\Exception\InvalidUuidStringException
+     * @expectedExceptionMessage Invalid UUID string:
+     */
+    public function testFromStringWithTrailingNewLine()
+    {
+        Uuid::fromString("d0d5f586-21d1-470c-8088-55c8857728dc\n");
+    }
+
+    /**
      */
     public function testFromStringWithUrn()
     {


### PR DESCRIPTION
A simple change to disallow UUIDs with a trailing newline, which IMO should not be valid (**please correct me if I'm wrong here!**).

This change updates the regex to use the PCRE_DOLLAR_ENDONLY modifier so that it matches only if it's the end of the string.

> D (PCRE_DOLLAR_ENDONLY)
If this modifier is set, a dollar metacharacter in the pattern matches only at the end of the subject string. Without this modifier, a dollar also matches immediately before the final character if it is a newline (but not before any other newlines). This modifier is ignored if m modifier is set. There is no equivalent to this modifier in Perl.

From http://php.net/manual/en/reference.pcre.pattern.modifiers.php