### PR TITLE
Support random_compat v9.99.99

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": "^5.4 || ^7.0",
-        "paragonie/random_compat": "^1.0|^2.0",
+        "paragonie/random_compat": "^1.0|^2.0|9.99.99",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {


### PR DESCRIPTION
v9.99.99 of random_compat is a no-op library specifically for PHP7.