### PR TITLE
Check whether php_uname is disabled

### DIFF
--- a/src/Provider/Node/SystemNodeProvider.php
+++ b/src/Provider/Node/SystemNodeProvider.php
@@ -62,7 +62,7 @@ class SystemNodeProvider implements NodeProviderInterface
      */
     protected function getIfconfig()
     {
-        if (strpos(strtolower(ini_get('disable_functions')), 'passthru') !== false) {
+        if (preg_match('(passthru|php_uname)', strtolower(ini_get('disable_functions'))) > 0) {
             return '';
         }
 
@@ -94,6 +94,10 @@ class SystemNodeProvider implements NodeProviderInterface
     protected function getSysfs()
     {
         $mac = false;
+
+        if (strpos(strtolower(ini_get('disable_functions')), 'php_uname') !== false) {
+            return false;
+        }
 
         if (strtoupper(php_uname('s')) === 'LINUX') {
             $addressPaths = glob('/sys/class/net/*/address', GLOB_NOSORT);

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -509,6 +509,37 @@ class SystemNodeProviderTest extends TestCase
     }
 
     /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGetNodeReturnsFalseWhenPhpUnameIsDisabled()
+    {
+        /*/ Arrange /*/
+        $this->arrangeMockFunctions(
+            null,
+            null,
+            null,
+            'NOT LINUX',
+            'PHP_UNAME,some_other_function'
+        );
+
+        /*/ Act /*/
+        $provider = new SystemNodeProvider();
+        $node = $provider->getNode();
+
+        /*/ Assert /*/
+        $this->assertMockFunctions(
+            null,
+            null,
+            null,
+            [['s']],
+            ['disabled_functions']
+        );
+
+        $this->assertFalse($node);
+    }
+
+    /**
      * Replaces the return value for functions with the given value or callback.
      *
      * @param callback|mixed|null $fileGetContentsBody


### PR DESCRIPTION
This PR solves #240 by checking if `php_uname` is disabled and returning a default value if it is. 