### PR TITLE
Check whether php_uname is disabled

### DIFF
--- a/src/Provider/Node/SystemNodeProvider.php
+++ b/src/Provider/Node/SystemNodeProvider.php
@@ -62,7 +62,7 @@ class SystemNodeProvider implements NodeProviderInterface
      */
     protected function getIfconfig()
     {
-        if (strpos(strtolower(ini_get('disable_functions')), 'passthru') !== false) {
+        if (preg_match('(passthru|php_uname)', strtolower(ini_get('disable_functions'))) > 0) {
             return '';
         }
 
@@ -93,6 +93,10 @@ class SystemNodeProvider implements NodeProviderInterface
      */
     protected function getSysfs()
     {
+        if (strpos(strtolower(ini_get('disable_functions')), 'php_uname') !== false) {
+            return false;
+        }
+
         $mac = false;
 
         if (strtoupper(php_uname('s')) === 'LINUX') {


### PR DESCRIPTION
This PR solves #240 by checking if `php_uname` is disabled and returning a default value if it is.