### PR TITLE
PHP_OS predefined constant was used instead of php_uname() function.

### DIFF
--- a/src/Provider/Node/SystemNodeProvider.php
+++ b/src/Provider/Node/SystemNodeProvider.php
@@ -67,7 +67,7 @@ class SystemNodeProvider implements NodeProviderInterface
         }
 
         ob_start();
-        switch (strtoupper(substr(php_uname('a'), 0, 3))) {
+        switch (strtoupper(substr(PHP_OS, 0, 3))) {
             case 'WIN':
                 passthru('ipconfig /all 2>&1');
                 break;
@@ -95,7 +95,7 @@ class SystemNodeProvider implements NodeProviderInterface
     {
         $mac = false;
 
-        if (strtoupper(php_uname('s')) === 'LINUX') {
+        if (strtoupper(PHP_OS) === 'LINUX') {
             $addressPaths = glob('/sys/class/net/*/address', GLOB_NOSORT);
 
             if (empty($addressPaths)) {


### PR DESCRIPTION
Bug Fixes #240 

PHP_OS predefined constant was used instead of php_uname() function.
