### PR TITLE
illegal access of properties at Uuuid.php

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -6,10 +6,10 @@
  * file that was distributed with this source code.
  *
  * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
- * @license   http://opensource.org/licenses/MIT MIT
- * @link      https://benramsey.com/projects/ramsey-uuid/ Documentation
- * @link      https://packagist.org/packages/ramsey/uuid Packagist
- * @link      https://github.com/ramsey/uuid GitHub
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link https://benramsey.com/projects/ramsey-uuid/ Documentation
+ * @link https://packagist.org/packages/ramsey/uuid Packagist
+ * @link https://github.com/ramsey/uuid GitHub
  */
 
 namespace Ramsey\Uuid;
@@ -43,63 +43,54 @@ class Uuid implements UuidInterface
 {
     /**
      * When this namespace is specified, the name string is a fully-qualified domain name.
-     *
      * @link http://tools.ietf.org/html/rfc4122#appendix-C
      */
     const NAMESPACE_DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 
     /**
      * When this namespace is specified, the name string is a URL.
-     *
      * @link http://tools.ietf.org/html/rfc4122#appendix-C
      */
     const NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
 
     /**
      * When this namespace is specified, the name string is an ISO OID.
-     *
      * @link http://tools.ietf.org/html/rfc4122#appendix-C
      */
     const NAMESPACE_OID = '6ba7b812-9dad-11d1-80b4-00c04fd430c8';
 
     /**
      * When this namespace is specified, the name string is an X.500 DN in DER or a text output format.
-     *
      * @link http://tools.ietf.org/html/rfc4122#appendix-C
      */
     const NAMESPACE_X500 = '6ba7b814-9dad-11d1-80b4-00c04fd430c8';
 
     /**
      * The nil UUID is special form of UUID that is specified to have all 128 bits set to zero.
-     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.7
      */
     const NIL = '00000000-0000-0000-0000-000000000000';
 
     /**
      * Reserved for NCS compatibility.
-     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.1
      */
     const RESERVED_NCS = 0;
 
     /**
      * Specifies the UUID layout given in RFC 4122.
-     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.1
      */
     const RFC_4122 = 2;
 
     /**
      * Reserved for Microsoft compatibility.
-     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.1
      */
     const RESERVED_MICROSOFT = 6;
 
     /**
      * Reserved for future definition.
-     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.1
      */
     const RESERVED_FUTURE = 7;
@@ -136,14 +127,12 @@ class Uuid implements UuidInterface
 
     /**
      * The factory to use when creating UUIDs.
-     *
      * @var UuidFactoryInterface
      */
     private static $factory = null;
 
     /**
      * The codec to use when encoding or decoding UUID strings.
-     *
      * @var CodecInterface
      */
     protected $codec;
@@ -167,7 +156,6 @@ class Uuid implements UuidInterface
 
     /**
      * The number converter to use for converting hex values to/from integers.
-     *
      * @var NumberConverterInterface
      */
     protected $converter;
@@ -188,13 +176,12 @@ class Uuid implements UuidInterface
      * $namespaceSha1Uuid = Uuid::uuid5(Uuid::NAMESPACE_URL, 'http://php.net/');
      * ```
      *
-     * @param array                    $fields    An array of fields from which to construct a UUID;
-     *                                            see {@see \Ramsey\Uuid\UuidInterface::getFieldsHex()} for array
-     *                                            structure.
+     * @param array $fields An array of fields from which to construct a UUID;
+     *     see {@see \Ramsey\Uuid\UuidInterface::getFieldsHex()} for array structure.
      * @param NumberConverterInterface $converter The number converter to use
-     *                                            for converting hex values to/from integers.
-     * @param CodecInterface           $codec     The codec to use when encoding or decoding
-     *                                            UUID strings.
+     *     for converting hex values to/from integers.
+     * @param CodecInterface $codec The codec to use when encoding or decoding
+     *     UUID strings.
      */
     public function __construct(
         array $fields,
@@ -246,9 +233,8 @@ class Uuid implements UuidInterface
      * Re-constructs the object from its serialized form.
      *
      * @param string $serialized
-     *
-     * @throws InvalidUuidStringException
      * @link http://php.net/manual/en/class.serializable.php
+     * @throws InvalidUuidStringException
      */
     public function unserialize($serialized)
     {
@@ -609,10 +595,15 @@ class Uuid implements UuidInterface
     public function getVersion()
     {
         if ($this->getVariant() == self::RFC_4122) {
-            return (int)(($this->getTimeHiAndVersion() >> 12) & 0x0f);
+            return (int) (($this->getTimeHiAndVersion() >> 12) & 0x0f);
         }
 
         return null;
+    }
+
+    public function toString()
+    {
+        return $this->codec->encode($this);
     }
 
     public function getCodec()
@@ -623,11 +614,6 @@ class Uuid implements UuidInterface
     public function getConverter()
     {
         return $this->converter;
-    }
-
-    public function toString()
-    {
-        return $this->codec->encode($this);
     }
 
     /**
@@ -658,7 +644,6 @@ class Uuid implements UuidInterface
      * Creates a UUID from a byte string.
      *
      * @param string $bytes
-     *
      * @return UuidInterface
      * @throws InvalidUuidStringException
      * @throws InvalidArgumentException
@@ -672,7 +657,6 @@ class Uuid implements UuidInterface
      * Creates a UUID from the string standard representation.
      *
      * @param string $name A string that specifies a UUID
-     *
      * @return UuidInterface
      * @throws InvalidUuidStringException
      */
@@ -685,7 +669,6 @@ class Uuid implements UuidInterface
      * Creates a UUID from a 128-bit integer string.
      *
      * @param string $integer String representation of 128-bit integer
-     *
      * @return UuidInterface
      * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
      * @throws InvalidUuidStringException
@@ -699,7 +682,6 @@ class Uuid implements UuidInterface
      * Check if a string is a valid UUID.
      *
      * @param string $uuid The string UUID to test
-     *
      * @return boolean
      */
     public static function isValid($uuid)
@@ -720,12 +702,11 @@ class Uuid implements UuidInterface
     /**
      * Generate a version 1 UUID from a host ID, sequence number, and the current time.
      *
-     * @param int|string $node     A 48-bit number representing the hardware address
-     *                             This number may be represented as an integer or a hexadecimal string.
-     * @param int        $clockSeq A 14-bit number used to help avoid duplicates that
-     *                             could arise when the clock is set backwards in time or if the node ID
-     *                             changes.
-     *
+     * @param int|string $node A 48-bit number representing the hardware address
+     *     This number may be represented as an integer or a hexadecimal string.
+     * @param int $clockSeq A 14-bit number used to help avoid duplicates that
+     *     could arise when the clock is set backwards in time or if the node ID
+     *     changes.
      * @return UuidInterface
      * @throws UnsatisfiedDependencyException if called on a 32-bit system and
      *     `Moontoast\Math\BigNumber` is not present
@@ -741,9 +722,8 @@ class Uuid implements UuidInterface
      * Generate a version 3 UUID based on the MD5 hash of a namespace identifier
      * (which is a UUID) and a name (which is a string).
      *
-     * @param string|UuidInterface $ns   The UUID namespace in which to create the named UUID
-     * @param string               $name The name to create a UUID for
-     *
+     * @param string|UuidInterface $ns The UUID namespace in which to create the named UUID
+     * @param string $name The name to create a UUID for
      * @return UuidInterface
      * @throws InvalidUuidStringException
      */
@@ -769,9 +749,8 @@ class Uuid implements UuidInterface
      * Generate a version 5 UUID based on the SHA-1 hash of a namespace
      * identifier (which is a UUID) and a name (which is a string).
      *
-     * @param string|UuidInterface $ns   The UUID namespace in which to create the named UUID
-     * @param string               $name The name to create a UUID for
-     *
+     * @param string|UuidInterface $ns The UUID namespace in which to create the named UUID
+     * @param string $name The name to create a UUID for
      * @return UuidInterface
      * @throws InvalidUuidStringException
      */

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -6,10 +6,10 @@
  * file that was distributed with this source code.
  *
  * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
- * @license http://opensource.org/licenses/MIT MIT
- * @link https://benramsey.com/projects/ramsey-uuid/ Documentation
- * @link https://packagist.org/packages/ramsey/uuid Packagist
- * @link https://github.com/ramsey/uuid GitHub
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://benramsey.com/projects/ramsey-uuid/ Documentation
+ * @link      https://packagist.org/packages/ramsey/uuid Packagist
+ * @link      https://github.com/ramsey/uuid GitHub
  */
 
 namespace Ramsey\Uuid;
@@ -43,54 +43,63 @@ class Uuid implements UuidInterface
 {
     /**
      * When this namespace is specified, the name string is a fully-qualified domain name.
+     *
      * @link http://tools.ietf.org/html/rfc4122#appendix-C
      */
     const NAMESPACE_DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 
     /**
      * When this namespace is specified, the name string is a URL.
+     *
      * @link http://tools.ietf.org/html/rfc4122#appendix-C
      */
     const NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
 
     /**
      * When this namespace is specified, the name string is an ISO OID.
+     *
      * @link http://tools.ietf.org/html/rfc4122#appendix-C
      */
     const NAMESPACE_OID = '6ba7b812-9dad-11d1-80b4-00c04fd430c8';
 
     /**
      * When this namespace is specified, the name string is an X.500 DN in DER or a text output format.
+     *
      * @link http://tools.ietf.org/html/rfc4122#appendix-C
      */
     const NAMESPACE_X500 = '6ba7b814-9dad-11d1-80b4-00c04fd430c8';
 
     /**
      * The nil UUID is special form of UUID that is specified to have all 128 bits set to zero.
+     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.7
      */
     const NIL = '00000000-0000-0000-0000-000000000000';
 
     /**
      * Reserved for NCS compatibility.
+     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.1
      */
     const RESERVED_NCS = 0;
 
     /**
      * Specifies the UUID layout given in RFC 4122.
+     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.1
      */
     const RFC_4122 = 2;
 
     /**
      * Reserved for Microsoft compatibility.
+     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.1
      */
     const RESERVED_MICROSOFT = 6;
 
     /**
      * Reserved for future definition.
+     *
      * @link http://tools.ietf.org/html/rfc4122#section-4.1.1
      */
     const RESERVED_FUTURE = 7;
@@ -127,12 +136,14 @@ class Uuid implements UuidInterface
 
     /**
      * The factory to use when creating UUIDs.
+     *
      * @var UuidFactoryInterface
      */
     private static $factory = null;
 
     /**
      * The codec to use when encoding or decoding UUID strings.
+     *
      * @var CodecInterface
      */
     protected $codec;
@@ -156,6 +167,7 @@ class Uuid implements UuidInterface
 
     /**
      * The number converter to use for converting hex values to/from integers.
+     *
      * @var NumberConverterInterface
      */
     protected $converter;
@@ -176,12 +188,13 @@ class Uuid implements UuidInterface
      * $namespaceSha1Uuid = Uuid::uuid5(Uuid::NAMESPACE_URL, 'http://php.net/');
      * ```
      *
-     * @param array $fields An array of fields from which to construct a UUID;
-     *     see {@see \Ramsey\Uuid\UuidInterface::getFieldsHex()} for array structure.
+     * @param array                    $fields    An array of fields from which to construct a UUID;
+     *                                            see {@see \Ramsey\Uuid\UuidInterface::getFieldsHex()} for array
+     *                                            structure.
      * @param NumberConverterInterface $converter The number converter to use
-     *     for converting hex values to/from integers.
-     * @param CodecInterface $codec The codec to use when encoding or decoding
-     *     UUID strings.
+     *                                            for converting hex values to/from integers.
+     * @param CodecInterface           $codec     The codec to use when encoding or decoding
+     *                                            UUID strings.
      */
     public function __construct(
         array $fields,
@@ -233,15 +246,16 @@ class Uuid implements UuidInterface
      * Re-constructs the object from its serialized form.
      *
      * @param string $serialized
-     * @link http://php.net/manual/en/class.serializable.php
+     *
      * @throws InvalidUuidStringException
+     * @link http://php.net/manual/en/class.serializable.php
      */
     public function unserialize($serialized)
     {
         $uuid = self::fromString($serialized);
-        $this->codec = $uuid->codec;
-        $this->converter = $uuid->converter;
-        $this->fields = $uuid->fields;
+        $this->codec = $uuid->getCodec();
+        $this->converter = $uuid->getConverter();
+        $this->fields = $uuid->getFieldsHex();
     }
 
     public function compareTo(UuidInterface $other)
@@ -595,10 +609,20 @@ class Uuid implements UuidInterface
     public function getVersion()
     {
         if ($this->getVariant() == self::RFC_4122) {
-            return (int) (($this->getTimeHiAndVersion() >> 12) & 0x0f);
+            return (int)(($this->getTimeHiAndVersion() >> 12) & 0x0f);
         }
 
         return null;
+    }
+
+    public function getCodec()
+    {
+        return $this->codec;
+    }
+
+    public function getConverter()
+    {
+        return $this->converter;
     }
 
     public function toString()
@@ -634,6 +658,7 @@ class Uuid implements UuidInterface
      * Creates a UUID from a byte string.
      *
      * @param string $bytes
+     *
      * @return UuidInterface
      * @throws InvalidUuidStringException
      * @throws InvalidArgumentException
@@ -647,6 +672,7 @@ class Uuid implements UuidInterface
      * Creates a UUID from the string standard representation.
      *
      * @param string $name A string that specifies a UUID
+     *
      * @return UuidInterface
      * @throws InvalidUuidStringException
      */
@@ -659,6 +685,7 @@ class Uuid implements UuidInterface
      * Creates a UUID from a 128-bit integer string.
      *
      * @param string $integer String representation of 128-bit integer
+     *
      * @return UuidInterface
      * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
      * @throws InvalidUuidStringException
@@ -672,6 +699,7 @@ class Uuid implements UuidInterface
      * Check if a string is a valid UUID.
      *
      * @param string $uuid The string UUID to test
+     *
      * @return boolean
      */
     public static function isValid($uuid)
@@ -692,11 +720,12 @@ class Uuid implements UuidInterface
     /**
      * Generate a version 1 UUID from a host ID, sequence number, and the current time.
      *
-     * @param int|string $node A 48-bit number representing the hardware address
-     *     This number may be represented as an integer or a hexadecimal string.
-     * @param int $clockSeq A 14-bit number used to help avoid duplicates that
-     *     could arise when the clock is set backwards in time or if the node ID
-     *     changes.
+     * @param int|string $node     A 48-bit number representing the hardware address
+     *                             This number may be represented as an integer or a hexadecimal string.
+     * @param int        $clockSeq A 14-bit number used to help avoid duplicates that
+     *                             could arise when the clock is set backwards in time or if the node ID
+     *                             changes.
+     *
      * @return UuidInterface
      * @throws UnsatisfiedDependencyException if called on a 32-bit system and
      *     `Moontoast\Math\BigNumber` is not present
@@ -712,8 +741,9 @@ class Uuid implements UuidInterface
      * Generate a version 3 UUID based on the MD5 hash of a namespace identifier
      * (which is a UUID) and a name (which is a string).
      *
-     * @param string|UuidInterface $ns The UUID namespace in which to create the named UUID
-     * @param string $name The name to create a UUID for
+     * @param string|UuidInterface $ns   The UUID namespace in which to create the named UUID
+     * @param string               $name The name to create a UUID for
+     *
      * @return UuidInterface
      * @throws InvalidUuidStringException
      */
@@ -739,8 +769,9 @@ class Uuid implements UuidInterface
      * Generate a version 5 UUID based on the SHA-1 hash of a namespace
      * identifier (which is a UUID) and a name (which is a string).
      *
-     * @param string|UuidInterface $ns The UUID namespace in which to create the named UUID
-     * @param string $name The name to create a UUID for
+     * @param string|UuidInterface $ns   The UUID namespace in which to create the named UUID
+     * @param string               $name The name to create a UUID for
+     *
      * @return UuidInterface
      * @throws InvalidUuidStringException
      */


### PR DESCRIPTION

## Description
The `unserialize` function at the Uuid.php creates an instance of Uuid from a serialized object.
After this, with this new instance, mutates its own properties: `codec`, `converters`, and `fields` based on that instance. 
The problem is: codec, converters, and fields are protected properties in some versions and even private in most recent versions. This is a violation according to PHP documentation.
Calling `unserialize`  at this point, will cause a problem.

To fix the problem, I created 2 new public functions: `getCodec` and `getConverters`, and change the calls inside of the `unserialize` function.

## Motivation and context
This change needs to be done for the `unserialize` function does not throw an exception.
I didn't find a specific issue related, so I decide to make the fix and open a Pull Request.

## How has this been tested?
The new version (this one that I'm submitting for PR) was tested inside a project that I'm working on (my employer's project). The exception was not thrown anymore.
Also ran there  `composer run-script test` the make sure nothing was changed.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have run `composer run-script test` locally, and there were no failures or errors.
