### PR TITLE
Minimal UUID immutability invariants at type-level

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,5 @@ phpstan-tests.neon export-ignore
 phpstan.neon       export-ignore
 phpunit.xml.dist   export-ignore
 resources/         export-ignore
+static-analysis/   export-ignore
 tests/             export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ script:
   - ./resources/scripts/cmd-proxy.sh ./vendor/bin/parallel-lint src tests
   - ./resources/scripts/cmd-proxy.sh ./vendor/bin/phpcs src tests --standard=psr2 -sp --colors
   - ./resources/scripts/cmd-proxy.sh composer run phpstan
+  - ./resources/scripts/cmd-proxy.sh composer run psalm
   - travis_wait ./resources/scripts/cmd-proxy.sh ./vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.5",
         "slevomat/coding-standard": "^6.0",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5",
+        "vimeo/psalm": "^3.7.2"
     },
     "suggest": {
         "ext-ctype": "Provides support for PHP Ctype functions",

--- a/composer.json
+++ b/composer.json
@@ -78,12 +78,14 @@
             "phpstan analyse -c phpstan.neon src --level max --no-progress",
             "phpstan analyse -c phpstan-tests.neon tests --level max --no-progress"
         ],
+        "psalm": "psalm",
         "phpunit": "phpunit --verbose --colors=always",
         "phpunit-coverage": "phpunit --verbose --colors=always --coverage-html build/coverage",
         "test": [
             "@lint",
             "@phpcs",
             "@phpstan",
+            "@psalm",
             "@phpunit"
         ]
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -333,7 +333,12 @@
         <properties>
             <property name="enableObjectTypeHint" value="true"/>
         </properties>
+
+        <!-- some native type hints cannot be added, because declaring them on pre-existing interfaces leads
+             to a major downstream BC break -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
     </rule>
+
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
 
     <!-- Require the return type hint to have one space (i.e. function foo(): ?int) -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,6 +12,7 @@
 
     <!-- Source and tests must follow the coding standard. -->
     <file>./src</file>
+    <file>./static-analysis</file>
     <file>./tests</file>
 
     <!-- Arguments for the command line runner. -->

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="static-analysis" />
+    </projectFiles>
+</psalm>

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -649,6 +649,9 @@ class Uuid implements UuidInterface
      *
      * @return UuidInterface A UuidInterface instance created from a binary
      *     string representation
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromBytes(string $bytes): UuidInterface
     {
@@ -662,6 +665,9 @@ class Uuid implements UuidInterface
      *
      * @return UuidInterface A UuidInterface instance created from a hexadecimal
      *     string representation
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromString(string $uuid): UuidInterface
     {
@@ -675,6 +681,9 @@ class Uuid implements UuidInterface
      *
      * @return UuidInterface A UuidInterface instance created from the string
      *     representation of a 128-bit integer
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function fromInteger(string $integer): UuidInterface
     {
@@ -687,6 +696,9 @@ class Uuid implements UuidInterface
      * @param string $uuid A string to validate as a UUID
      *
      * @return bool True if the string is a valid UUID, false otherwise
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function isValid(string $uuid): bool
     {

--- a/src/UuidInterface.php
+++ b/src/UuidInterface.php
@@ -129,7 +129,7 @@ interface UuidInterface extends JsonSerializable, Serializable
     /**
      * Returns the 128-bit integer value of the UUID as a string
      *
-     * @return mixed
+     * @return string
      */
     public function getInteger();
 

--- a/src/UuidInterface.php
+++ b/src/UuidInterface.php
@@ -22,6 +22,8 @@ use Serializable;
 /**
  * A UUID is a universally unique identifier adhering to an agreed-upon
  * representation format and standard for generation
+ *
+ * @psalm-immutable
  */
 interface UuidInterface extends JsonSerializable, Serializable
 {

--- a/static-analysis/UuidIsImmutable.php
+++ b/static-analysis/UuidIsImmutable.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the ramsey/uuid library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace Ramsey\Uuid\StaticAnalysis;
+
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * This is a static analysis fixture to verify that the API signature
+ * of a UUID allows for pure operations. Almost all methods will seem to be
+ * redundant or trivial: that's normal, we're just verifying the
+ * transitivity of immutable type signatures.
+ *
+ * Please note that this does not guarantee that the internals of the UUID
+ * library are pure/safe, but just that the declared API to the outside world
+ * is seen as immutable.
+ */
+final class UuidIsImmutable
+{
+    /** @psalm-pure */
+    public static function pureCompareTo(UuidInterface $a, UuidInterface $b): int
+    {
+        return $a->compareTo($b);
+    }
+
+    /** @psalm-pure */
+    public static function pureEquals(UuidInterface $a, ?object $b): bool
+    {
+        return $a->equals($b);
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @psalm-pure
+     */
+    public static function pureGetters(UuidInterface $a): array
+    {
+        return [
+            $a->getBytes(),
+            $a->getNumberConverter(),
+            $a->getHex(),
+            $a->getFieldsHex(),
+            $a->getClockSeqHiAndReservedHex(),
+            $a->getClockSeqLowHex(),
+            $a->getClockSequenceHex(),
+            $a->getDateTime(),
+            $a->getInteger(),
+            $a->getLeastSignificantBitsHex(),
+            $a->getMostSignificantBitsHex(),
+            $a->getNodeHex(),
+            $a->getTimeHiAndVersionHex(),
+            $a->getTimeLowHex(),
+            $a->getTimeMidHex(),
+            $a->getTimestampHex(),
+            $a->getUrn(),
+            $a->getVariant(),
+            $a->getVersion(),
+            $a->toString(),
+            $a->__toString(),
+        ];
+    }
+
+    /**
+     * @return UuidInterface[]|bool[]
+     *
+     * @psalm-pure
+     */
+    public static function pureStaticUuidApi(): array
+    {
+        $id = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
+
+        return [
+            Uuid::fromBytes($id->getBytes()),
+            Uuid::fromInteger($id->getInteger()),
+            Uuid::isValid('ff6f8cb0-c57d-11e1-9b21-0800200c9a66'),
+        ];
+    }
+}


### PR DESCRIPTION
## Description

This patch adds `@psalm-immutable` to `UuidInterface`, and marks the named constructors of `Uuid` as `@psalm-pure` too.

This is very similar to https://github.com/moneyphp/money/pull/576 in spirit and implementation

## Motivation and context

UUIDs are identifiers that cross serialization and address space boundaries, and should be treated as immutable values.

## How has this been tested?

A new `static-analysis` (not exported) directory has been created: it includes fixtures that are verifying the transitivity of the added `@psalm-pure` and `@psalm-immutable` type invariant markers.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Please note that this will cause type changes for downstreams implementors (custom implementations) of `UuidInterface` that do use `vimeo/psalm`: if their code does not follow `@psalm-immutable` invariants, they will get a build failure. No runtime behavior changes apply, so no new warnings/exceptions.

## Checklist:

- [x] My code follows the code style of this project.
- [x] ~~My change requires a change to the documentation.~~ (inapplicable)
- [x] ~~I have updated the documentation accordingly.~~ (inapplicable)
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run-script test` locally, and there were no failures or errors.
