### PR TITLE
Run Psalm on src as well as Static Analysis Fixture

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@ phpcs.xml.dist     export-ignore
 phpstan-tests.neon export-ignore
 phpstan.neon       export-ignore
 phpunit.xml.dist   export-ignore
+psalm-baseline.xml export-ignore
 resources/         export-ignore
 static-analysis/   export-ignore
 tests/             export-ignore

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,11 +8,6 @@
       <code>int</code>
     </InvalidReturnType>
   </file>
-  <file src="src/Codec/OrderedTimeCodec.php">
-    <MixedAssignment occurrences="1">
-      <code>$hex</code>
-    </MixedAssignment>
-  </file>
   <file src="src/Codec/StringCodec.php">
     <MixedArgument occurrences="1">
       <code>$hexUuid[1]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -127,9 +127,6 @@
       <code>getValidator</code>
       <code>validate</code>
     </ImpureMethodCall>
-    <MissingImmutableAnnotation occurrences="1">
-      <code>Uuid</code>
-    </MissingImmutableAnnotation>
     <PossiblyInvalidArgument occurrences="1">
       <code>$exception-&gt;getCode()</code>
     </PossiblyInvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,20 +8,6 @@
       <code>int</code>
     </InvalidReturnType>
   </file>
-  <file src="src/Codec/GuidStringCodec.php">
-    <MixedArgument occurrences="2">
-      <code>$components[1]</code>
-      <code>$components[2]</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="3">
-      <code>$components[0]</code>
-      <code>$components[1]</code>
-      <code>$components[2]</code>
-    </MixedAssignment>
-    <ReferenceConstraintViolation occurrences="1">
-      <code>$components</code>
-    </ReferenceConstraintViolation>
-  </file>
   <file src="src/Codec/OrderedTimeCodec.php">
     <MixedAssignment occurrences="1">
       <code>$hex</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,6 +6,10 @@
     </MixedArgument>
   </file>
   <file src="src/DegradedUuid.php">
+    <ImpureMethodCall occurrences="2">
+      <code>fromHex</code>
+      <code>convertTime</code>
+    </ImpureMethodCall>
     <PossiblyInvalidArgument occurrences="1">
       <code>$exception-&gt;getCode()</code>
     </PossiblyInvalidArgument>
@@ -86,7 +90,13 @@
     <DocblockTypeContradiction occurrences="1">
       <code>self::$factory</code>
     </DocblockTypeContradiction>
-    <ImpureMethodCall occurrences="9">
+    <ImpureMethodCall occurrences="15">
+      <code>encodeBinary</code>
+      <code>convertTime</code>
+      <code>fromHex</code>
+      <code>fromHex</code>
+      <code>fromHex</code>
+      <code>encode</code>
       <code>getFactory</code>
       <code>fromBytes</code>
       <code>getFactory</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.7.2@d9cae720c1af31db9ba27c2bc1fcf9b0dd092fb0">
-  <file src="src/BinaryUtils.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>$timeHi</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>int</code>
-    </InvalidReturnType>
-  </file>
   <file src="src/Codec/StringCodec.php">
     <MixedArgument occurrences="1">
       <code>$hexUuid[1]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -144,14 +144,5 @@
     <MixedAssignment occurrences="1">
       <code>$hash</code>
     </MixedAssignment>
-    <PossiblyNullPropertyAssignmentValue occurrences="7">
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -19,9 +19,6 @@
     </MixedArgument>
   </file>
   <file src="src/DegradedUuid.php">
-    <MissingImmutableAnnotation occurrences="1">
-      <code>DegradedUuid</code>
-    </MissingImmutableAnnotation>
     <PossiblyInvalidArgument occurrences="1">
       <code>$exception-&gt;getCode()</code>
     </PossiblyInvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -23,13 +23,6 @@
     </ReferenceConstraintViolation>
   </file>
   <file src="src/Codec/OrderedTimeCodec.php">
-    <MixedArgument occurrences="5">
-      <code>$hex</code>
-      <code>$hex</code>
-      <code>$hex</code>
-      <code>$hex</code>
-      <code>$hex</code>
-    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$hex</code>
     </MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.7.2@d9cae720c1af31db9ba27c2bc1fcf9b0dd092fb0">
+  <file src="src/BinaryUtils.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$timeHi</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>int</code>
+    </InvalidReturnType>
+  </file>
+  <file src="src/Codec/GuidStringCodec.php">
+    <MixedArgument occurrences="2">
+      <code>$components[1]</code>
+      <code>$components[2]</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$components[0]</code>
+      <code>$components[1]</code>
+      <code>$components[2]</code>
+    </MixedAssignment>
+    <ReferenceConstraintViolation occurrences="1">
+      <code>$components</code>
+    </ReferenceConstraintViolation>
+  </file>
+  <file src="src/Codec/OrderedTimeCodec.php">
+    <MixedArgument occurrences="5">
+      <code>$hex</code>
+      <code>$hex</code>
+      <code>$hex</code>
+      <code>$hex</code>
+      <code>$hex</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$hex</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Codec/StringCodec.php">
+    <MixedArgument occurrences="1">
+      <code>$hexUuid[1]</code>
+    </MixedArgument>
+  </file>
+  <file src="src/DegradedUuid.php">
+    <MissingImmutableAnnotation occurrences="1">
+      <code>DegradedUuid</code>
+    </MissingImmutableAnnotation>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$exception-&gt;getCode()</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="src/Generator/DefaultTimeGenerator.php">
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$exception-&gt;getCode()</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$node</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="src/Generator/PeclUuidRandomGenerator.php">
+    <MixedAssignment occurrences="1">
+      <code>$uuid</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>uuid_parse($uuid)</code>
+    </MixedReturnStatement>
+    <UndefinedFunction occurrences="2">
+      <code>uuid_create(UUID_TYPE_RANDOM)</code>
+      <code>uuid_parse($uuid)</code>
+    </UndefinedFunction>
+  </file>
+  <file src="src/Generator/PeclUuidTimeGenerator.php">
+    <MixedAssignment occurrences="1">
+      <code>$uuid</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>uuid_parse($uuid)</code>
+    </MixedReturnStatement>
+    <UndefinedFunction occurrences="2">
+      <code>uuid_create(UUID_TYPE_TIME)</code>
+      <code>uuid_parse($uuid)</code>
+    </UndefinedFunction>
+  </file>
+  <file src="src/Generator/RandomBytesGenerator.php">
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$exception-&gt;getCode()</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="src/Provider/Node/RandomNodeProvider.php">
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$exception-&gt;getCode()</code>
+      <code>hexdec(bin2hex($nodeMsb)) | 0x010000</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="src/Provider/Node/SystemNodeProvider.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$addressPath</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="6">
+      <code>$node</code>
+      <code>constant('PHP_OS')</code>
+      <code>constant('PHP_OS')</code>
+      <code>$addressPath</code>
+      <code>$addressPath</code>
+      <code>$macs</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$node</code>
+      <code>$node</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>getNode</code>
+    </MixedInferredReturnType>
+    <TypeDoesNotContainType occurrences="1">
+      <code>is_array($node)</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/Uuid.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>self::$factory</code>
+    </DocblockTypeContradiction>
+    <ImpureMethodCall occurrences="9">
+      <code>getFactory</code>
+      <code>fromBytes</code>
+      <code>getFactory</code>
+      <code>fromString</code>
+      <code>getFactory</code>
+      <code>fromInteger</code>
+      <code>getFactory</code>
+      <code>getValidator</code>
+      <code>validate</code>
+    </ImpureMethodCall>
+    <MissingImmutableAnnotation occurrences="1">
+      <code>Uuid</code>
+    </MissingImmutableAnnotation>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$exception-&gt;getCode()</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="src/UuidFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$hash</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$hash</code>
+    </MixedAssignment>
+    <PossiblyNullPropertyAssignmentValue occurrences="7">
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,8 +5,17 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="static-analysis" />
+
+        <!-- At time of writing Psalm reports 65 errors in src, but these are suppressed by being listed in the errorBaseline file
+             referenced above. Any new errors will cause a build failure. It might be a good project for someone to go through the errorBaseline
+             and delete as many issues as possible, updating the code as they go to top producing the errors. 
+
+             To see the errors in Psalm output, run psalm with the `<double-hyphen> ignore-baseline` option (literal double-hypen is not permitted in XML comment)
+             -->
+        <directory name="src" />
     </projectFiles>
 </psalm>

--- a/src/BinaryUtils.php
+++ b/src/BinaryUtils.php
@@ -54,6 +54,8 @@ class BinaryUtils
         $timeHi = hexdec($timeHi) & 0x0fff;
         $timeHi |= $version << 12;
 
+        assert(\is_int($timeHi));
+        
         return $timeHi;
     }
 }

--- a/src/Codec/GuidStringCodec.php
+++ b/src/Codec/GuidStringCodec.php
@@ -78,12 +78,15 @@ class GuidStringCodec extends StringCodec
     private function swapFields(array &$components): void
     {
         $hex = unpack('H*', pack('L', hexdec($components[0])));
+        assert(is_string($hex[1]));
         $components[0] = $hex[1];
 
         $hex = unpack('H*', pack('S', hexdec($components[1])));
+        assert(is_string($hex[1]));
         $components[1] = $hex[1];
 
         $hex = unpack('H*', pack('S', hexdec($components[2])));
+        assert(is_string($hex[1]));
         $components[2] = $hex[1];
     }
 }

--- a/src/Codec/OrderedTimeCodec.php
+++ b/src/Codec/OrderedTimeCodec.php
@@ -77,6 +77,8 @@ class OrderedTimeCodec extends StringCodec
 
         $hex = unpack('H*', $bytes)[1];
 
+        assert(is_string($hex));
+
         // Rearrange the fields to their original order
         $hex = substr($hex, 8, 4)
             . substr($hex, 12, 4)

--- a/src/Codec/OrderedTimeCodec.php
+++ b/src/Codec/OrderedTimeCodec.php
@@ -75,9 +75,11 @@ class OrderedTimeCodec extends StringCodec
             );
         }
 
-        $hex = unpack('H*', $bytes)[1];
+        $unpacked = unpack('H*', $bytes);
 
-        assert(is_string($hex));
+        assert(is_string($unpacked[1]));
+
+        $hex = $unpacked[1];
 
         // Rearrange the fields to their original order
         $hex = substr($hex, 8, 4)

--- a/src/Converter/Time/PhpTimeConverter.php
+++ b/src/Converter/Time/PhpTimeConverter.php
@@ -46,6 +46,7 @@ class PhpTimeConverter implements TimeConverterInterface
         // UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
         $uuidTime = ((int) $seconds * 10000000) + ((int) $microSeconds * 10) + 0x01b21dd213814000;
 
+        /** @psalm-suppress MixedArgument*/
         return [
             'low' => sprintf('%08x', $uuidTime & 0xffffffff),
             'mid' => sprintf('%04x', ($uuidTime >> 32) & 0xffff),

--- a/src/DegradedUuid.php
+++ b/src/DegradedUuid.php
@@ -26,6 +26,8 @@ use Ramsey\Uuid\Exception\UnsupportedOperationException;
  * Some of the functionality of a DegradedUuid is not present or degraded, since
  * 32-bit systems are unable to perform the necessary mathematical operations or
  * represent the integers appropriately.
+ *
+ * @psalm-immutable
  */
 class DegradedUuid extends Uuid
 {

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -34,6 +34,8 @@ use Ramsey\Uuid\Exception\UnsupportedOperationException;
  * Note that `uuid1()` may compromise privacy since it creates a UUID containing
  * the computer’s network address. `uuid4()` creates a random UUID.
  *
+ * @psalm-immutable
+ *
  * @link http://tools.ietf.org/html/rfc4122 RFC 4122
  */
 class Uuid implements UuidInterface

--- a/src/UuidFactory.php
+++ b/src/UuidFactory.php
@@ -27,37 +27,37 @@ class UuidFactory implements UuidFactoryInterface
     /**
      * @var CodecInterface
      */
-    private $codec = null;
+    private $codec;
 
     /**
      * @var NodeProviderInterface
      */
-    private $nodeProvider = null;
+    private $nodeProvider;
 
     /**
      * @var NumberConverterInterface
      */
-    private $numberConverter = null;
+    private $numberConverter;
 
     /**
      * @var RandomGeneratorInterface
      */
-    private $randomGenerator = null;
+    private $randomGenerator;
 
     /**
      * @var TimeGeneratorInterface
      */
-    private $timeGenerator = null;
+    private $timeGenerator;
 
     /**
      * @var UuidBuilderInterface
      */
-    private $uuidBuilder = null;
+    private $uuidBuilder;
 
     /**
      * @var ValidatorInterface
      */
-    private $validator = null;
+    private $validator;
 
     /**
      * @param FeatureSet $features A set of available features in the current environment


### PR DESCRIPTION
Adds [Psalm](https://psalm.dev/) Static Analysis checks to cover src folder, in addition to the `static-analysis` folder which @Ocramius recently added.

## Description
This changes the psalm xml config to make it include the `src` folder, and also uses the psalm 'baselining' feature to make Psalm ignore all existing errors (or apparent errors) that it detected when run on my machine.

A great follow-up project would be to go through those errors and fix them one-by-one, or in cases where they can't or shouldn't be fixed suppress them using an inline code comment and add some more information. In the meantime having this merged and keeping the build green will prevent any additional errors that Psalm can detect getting in.

## How has this been tested?
Psalm is already run as part of the Travis config.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run-script test` locally, and there were no failures or errors.
