### PR TITLE
Use brick math package instead of moontoast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ services:
 jobs:
   fast_finish: true
   include:
-    - php: 5.4
-      dist: trusty
-    - php: 5.5
-      dist: trusty
-    - php: 5.6
-    - php: 7.0
     - php: 7.1
     - php: 7.1
       arch: s390x

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ still `Rhumsaa`.
 
 Some methods in this library have requirements due to integer size restrictions
 on 32-bit and 64-bit builds of PHP. A 64-bit build of PHP and the
-[Moontoast\Math][] library are recommended. However, this library is designed to
-work on 32-bit builds of PHP without Moontoast\Math, with some degraded
+[Brick\Math][] library are recommended. However, this library is designed to
+work on 32-bit builds of PHP without Brick\Math, with some degraded
 functionality. Please check the API documentation for more information.
 
 If a particular requirement is not present, then an
@@ -140,7 +140,7 @@ try {
 } catch (UnsatisfiedDependencyException $e) {
 
     // Some dependency was not met. Either the method cannot be called on a
-    // 32-bit system, or it can, but it relies on Moontoast\Math to be present.
+    // 32-bit system, or it can, but it relies on Brick\Math to be present.
     echo 'Caught exception: ' . $e->getMessage() . "\n";
 
 }
@@ -164,7 +164,7 @@ information.
 [javauuid]: http://docs.oracle.com/javase/6/docs/api/java/util/UUID.html
 [pyuuid]: http://docs.python.org/3/library/uuid.html
 [composer]: http://getcomposer.org/
-[moontoast\math]: https://packagist.org/packages/moontoast/math
+[brick\math]: https://packagist.org/packages/brick/math
 [wiki-cookbook]: https://github.com/ramsey/uuid/wiki/Ramsey%5CUuid-Cookbook
 [contributing.md]: https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^5.4 | ^7 | ^8",
+        "php": "^7 | ^8",
         "ext-json": "*",
         "paragonie/random_compat": "^1 | ^2 | 9.99.99",
         "symfony/polyfill-ctype": "^1.8"

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {
+        "brick/math": "^0.8.8",
         "codeception/aspect-mock": "^1 | ^2",
         "doctrine/annotations": "^1.2",
         "goaop/framework": "1.0.0-alpha.2 | ^1 | ^2.1",
         "jakub-onderka/php-parallel-lint": "^1",
         "mockery/mockery": "^0.9.11 | ^1",
-        "moontoast/math": "^1.1",
         "paragonie/random-lib": "^2",
         "php-mock/php-mock-phpunit": "^0.3 | ^1.1",
         "phpunit/phpunit": "^4.8 | ^5.4 | ^6.5",

--- a/src/Converter/Number/BigNumberConverter.php
+++ b/src/Converter/Number/BigNumberConverter.php
@@ -14,41 +14,41 @@
 
 namespace Ramsey\Uuid\Converter\Number;
 
-use Moontoast\Math\BigNumber;
+use Brick\Math\BigInteger;
 use Ramsey\Uuid\Converter\NumberConverterInterface;
 
 /**
  * BigNumberConverter converts UUIDs from hexadecimal characters into
- * moontoast/math `BigNumber` representations of integers and vice versa
+ * brick/math `BigInteger` representations of integers and vice versa
  */
 class BigNumberConverter implements NumberConverterInterface
 {
     /**
-     * Converts a hexadecimal number into a `Moontoast\Math\BigNumber` representation
+     * Converts a hexadecimal number into a `Brick\Math\BigInteger` representation
      *
      * @param string $hex The hexadecimal string representation to convert
-     * @return BigNumber
+     * @return BigInteger
      */
     public function fromHex($hex)
     {
-        $number = BigNumber::convertToBase10($hex, 16);
+        $number = BigInteger::fromBase($hex, 16)->toBase(10);
 
-        return new BigNumber($number);
+        return BigInteger::of($number);
     }
 
     /**
-     * Converts an integer or `Moontoast\Math\BigNumber` integer representation
+     * Converts an integer or `Brick\Math\BigInteger` integer representation
      * into a hexadecimal string representation
      *
-     * @param int|string|BigNumber $integer An integer or `Moontoast\Math\BigNumber`
+     * @param int|string|BigInteger $integer An integer or `Brick\Math\BigInteger`
      * @return string Hexadecimal string
      */
     public function toHex($integer)
     {
-        if (!$integer instanceof BigNumber) {
-            $integer = new BigNumber($integer);
+        if (!$integer instanceof BigInteger) {
+            $integer = BigInteger::of($integer);
         }
 
-        return BigNumber::convertFromBase10($integer, 16);
+        return BigInteger::fromBase($integer, 10)->toBase(16);
     }
 }

--- a/src/Converter/Number/DegradedNumberConverter.php
+++ b/src/Converter/Number/DegradedNumberConverter.php
@@ -36,7 +36,7 @@ class DegradedNumberConverter implements NumberConverterInterface
         throw new UnsatisfiedDependencyException(
             'Cannot call ' . __METHOD__ . ' without support for large '
             . 'integers, since integer is an unsigned '
-            . '128-bit integer; Moontoast\Math\BigNumber is required.'
+            . '128-bit integer; Brick\Math\BigInteger is required.'
         );
     }
 
@@ -52,7 +52,7 @@ class DegradedNumberConverter implements NumberConverterInterface
         throw new UnsatisfiedDependencyException(
             'Cannot call ' . __METHOD__ . ' without support for large '
             . 'integers, since integer is an unsigned '
-            . '128-bit integer; Moontoast\Math\BigNumber is required. '
+            . '128-bit integer; Brick\Math\BigInteger is required. '
         );
     }
 }

--- a/src/Converter/NumberConverterInterface.php
+++ b/src/Converter/NumberConverterInterface.php
@@ -30,7 +30,7 @@ interface NumberConverterInterface
      *
      * @param string $hex The hexadecimal string representation to convert
      * @return mixed
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      */
     public function fromHex($hex);
 
@@ -42,7 +42,7 @@ interface NumberConverterInterface
      *     a true integer, a string integer, or a object representation that
      *     this converter can understand
      * @return string Hexadecimal string
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      */
     public function toHex($integer);
 }

--- a/src/Converter/Time/BigNumberTimeConverter.php
+++ b/src/Converter/Time/BigNumberTimeConverter.php
@@ -14,11 +14,11 @@
 
 namespace Ramsey\Uuid\Converter\Time;
 
-use Moontoast\Math\BigNumber;
+use Brick\Math\BigInteger;
 use Ramsey\Uuid\Converter\TimeConverterInterface;
 
 /**
- * BigNumberTimeConverter uses the moontoast/math library's `BigNumber` to
+ * BigNumberTimeConverter uses the brick/math library's `BigInteger` to
  * provide facilities for converting parts of time into representations that may
  * be used in UUIDs
  */
@@ -35,20 +35,18 @@ class BigNumberTimeConverter implements TimeConverterInterface
      */
     public function calculateTime($seconds, $microSeconds)
     {
-        $uuidTime = new BigNumber('0');
+        $uuidTime = BigInteger::of('0');
 
-        $sec = new BigNumber($seconds);
-        $sec->multiply('10000000');
+        $sec = BigInteger::of($seconds)->multipliedBy('10000000');
 
-        $usec = new BigNumber($microSeconds);
-        $usec->multiply('10');
+        $usec = BigInteger::of($microSeconds)->multipliedBy('10');
 
-        $uuidTime
-            ->add($sec)
-            ->add($usec)
-            ->add('122192928000000000');
+        $uuidTime = $uuidTime
+            ->plus($sec)
+            ->plus($usec)
+            ->plus('122192928000000000');
 
-        $uuidTimeHex = sprintf('%016s', $uuidTime->convertToBase(16));
+        $uuidTimeHex = sprintf('%016s', $uuidTime->toBase(16));
 
         return [
             'low' => substr($uuidTimeHex, 8),

--- a/src/Converter/Time/DegradedTimeConverter.php
+++ b/src/Converter/Time/DegradedTimeConverter.php
@@ -20,7 +20,7 @@ use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;
 /**
  * DegradedTimeConverter throws `UnsatisfiedDependencyException` exceptions
  * if attempting to use time conversion functionality in an environment that
- * does not support large integers (i.e. when moontoast/math is not available)
+ * does not support large integers (i.e. when brick/math is not available)
  */
 class DegradedTimeConverter implements TimeConverterInterface
 {
@@ -30,13 +30,13 @@ class DegradedTimeConverter implements TimeConverterInterface
      * @param string $seconds
      * @param string $microSeconds
      * @return void
-     * @throws UnsatisfiedDependencyException if called on a 32-bit system and `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if called on a 32-bit system and `Brick\Math\BigInteger` is not present
      */
     public function calculateTime($seconds, $microSeconds)
     {
         throw new UnsatisfiedDependencyException(
             'When calling ' . __METHOD__ . ' on a 32-bit system, '
-            . 'Moontoast\Math\BigNumber must be present.'
+            . 'Brick\Math\BigInteger must be present.'
         );
     }
 }

--- a/src/Converter/TimeConverterInterface.php
+++ b/src/Converter/TimeConverterInterface.php
@@ -30,7 +30,7 @@ interface TimeConverterInterface
      * @param string $microSeconds
      * @return string[] An array guaranteed to contain `low`, `mid`, and `high` keys
      * @throws UnsatisfiedDependencyException if called on a 32-bit system and
-     *     `Moontoast\Math\BigNumber` is not present
+     *     `Brick\Math\BigInteger` is not present
      * @link http://tools.ietf.org/html/rfc4122#section-4.2.2
      */
     public function calculateTime($seconds, $microSeconds);

--- a/src/DegradedUuid.php
+++ b/src/DegradedUuid.php
@@ -14,8 +14,9 @@
 
 namespace Ramsey\Uuid;
 
+use Brick\Math\RoundingMode;
 use DateTime;
-use Moontoast\Math\BigNumber;
+use Brick\Math\BigInteger;
 use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;
 use Ramsey\Uuid\Exception\UnsupportedOperationException;
 
@@ -37,11 +38,10 @@ class DegradedUuid extends Uuid
 
         $time = $this->converter->fromHex($this->getTimestampHex());
 
-        $ts = new BigNumber($time, 20);
-        $ts->subtract('122192928000000000');
-        $ts->divide('10000000.0');
-        $ts->round();
-        $unixTime = $ts->getValue();
+        $ts = BigInteger::fromBase($time, 20);
+        $ts = $ts->minus('122192928000000000')
+            ->dividedBy('10000000.0', RoundingMode::FLOOR);
+        $unixTime = $ts->__toString();
 
         return new DateTime("@{$unixTime}");
     }

--- a/src/FeatureSet.php
+++ b/src/FeatureSet.php
@@ -102,8 +102,8 @@ class FeatureSet
      * @param bool $useGuids Whether to build UUIDs using the `GuidStringCodec`
      * @param bool $force32Bit Whether to force the use of 32-bit functionality
      *     (primarily for testing purposes)
-     * @param bool $forceNoBigNumber Whether to disable the use of moontoast/math
-     *     `BigNumber` (primarily for testing purposes)
+     * @param bool $forceNoBigNumber Whether to disable the use of brick/math
+     *     `BigInteger` (primarily for testing purposes)
      * @param bool $ignoreSystemNode Whether to disable attempts to check for
      *     the system host ID (primarily for testing purposes)
      * @param bool $enablePecl Whether to enable the use of the `PeclUuidTimeGenerator`
@@ -314,13 +314,13 @@ class FeatureSet
     }
 
     /**
-     * Returns true if the system has `Moontoast\Math\BigNumber`
+     * Returns true if the system has `Brick\Math\BigInteger`
      *
      * @return bool
      */
     protected function hasBigNumber()
     {
-        return class_exists('Moontoast\Math\BigNumber') && !$this->disableBigNumber;
+        return class_exists('Brick\Math\BigInteger') && !$this->disableBigNumber;
     }
 
     /**

--- a/src/Generator/CombGenerator.php
+++ b/src/Generator/CombGenerator.php
@@ -56,7 +56,7 @@ class CombGenerator implements RandomGeneratorInterface
      *
      * @param integer $length The number of bytes of random binary data to generate
      * @return string A binary string
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      * @throws InvalidArgumentException if length is not a positive integer
      * @throws Exception
      */

--- a/src/Generator/DefaultTimeGenerator.php
+++ b/src/Generator/DefaultTimeGenerator.php
@@ -76,7 +76,7 @@ class DefaultTimeGenerator implements TimeGeneratorInterface
      *     changes.
      * @return string A binary string
      * @throws UnsatisfiedDependencyException if called on a 32-bit system and
-     *     `Moontoast\Math\BigNumber` is not present
+     *     `Brick\Math\BigInteger` is not present
      * @throws InvalidArgumentException
      * @throws Exception if it was not possible to gather sufficient entropy
      */

--- a/src/Generator/RandomGeneratorInterface.php
+++ b/src/Generator/RandomGeneratorInterface.php
@@ -29,7 +29,7 @@ interface RandomGeneratorInterface
      *
      * @param integer $length The number of bytes of random binary data to generate
      * @return string A binary string
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigInteger` is not present
      * @throws InvalidArgumentException
      * @throws Exception if it was not possible to gather sufficient entropy
      */

--- a/src/Generator/TimeGeneratorInterface.php
+++ b/src/Generator/TimeGeneratorInterface.php
@@ -35,7 +35,7 @@ interface TimeGeneratorInterface
      *     changes.
      * @return string A binary string
      * @throws UnsatisfiedDependencyException if called on a 32-bit system and
-     *     `Moontoast\Math\BigNumber` is not present
+     *     `Brick\Math\BigInteger` is not present
      * @throws InvalidArgumentException
      * @throws Exception if it was not possible to gather sufficient entropy
      */

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -408,7 +408,7 @@ class Uuid implements UuidInterface
      * Returns the least significant 64 bits of this UUID's 128 bit value.
      *
      * @return mixed Converted representation of the unsigned 64-bit integer value
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      */
     public function getLeastSignificantBits()
     {
@@ -429,7 +429,7 @@ class Uuid implements UuidInterface
      * Returns the most significant 64 bits of this UUID's 128 bit value.
      *
      * @return mixed Converted representation of the unsigned 64-bit integer value
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      */
     public function getMostSignificantBits()
     {
@@ -660,7 +660,7 @@ class Uuid implements UuidInterface
      *
      * @param string $integer String representation of 128-bit integer
      * @return UuidInterface
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      * @throws InvalidUuidStringException
      */
     public static function fromInteger($integer)
@@ -699,7 +699,7 @@ class Uuid implements UuidInterface
      *     changes.
      * @return UuidInterface
      * @throws UnsatisfiedDependencyException if called on a 32-bit system and
-     *     `Moontoast\Math\BigNumber` is not present
+     *     `Brick\Math\BigInteger` is not present
      * @throws InvalidArgumentException
      * @throws Exception if it was not possible to gather sufficient entropy
      */
@@ -726,7 +726,7 @@ class Uuid implements UuidInterface
      * Generate a version 4 (random) UUID.
      *
      * @return UuidInterface
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      * @throws InvalidArgumentException
      * @throws Exception
      */

--- a/src/UuidFactoryInterface.php
+++ b/src/UuidFactoryInterface.php
@@ -35,7 +35,7 @@ interface UuidFactoryInterface
      *     changes.
      * @return UuidInterface
      * @throws UnsatisfiedDependencyException if called on a 32-bit system and
-     *     `Moontoast\Math\BigNumber` is not present
+     *     `Brick\Math\BigInteger` is not present
      * @throws InvalidArgumentException
      * @throws Exception if it was not possible to gather sufficient entropy
      */
@@ -56,7 +56,7 @@ interface UuidFactoryInterface
      * Generate a version 4 (random) UUID.
      *
      * @return UuidInterface
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      * @throws InvalidArgumentException
      * @throws Exception
      */
@@ -101,7 +101,7 @@ interface UuidFactoryInterface
      * @param mixed $integer The integer to use when creating a `Uuid` from an
      *     integer; may be of any type understood by the configured number converter
      * @return UuidInterface
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      * @throws InvalidUuidStringException
      */
     public function fromInteger($integer);

--- a/src/UuidInterface.php
+++ b/src/UuidInterface.php
@@ -128,7 +128,7 @@ interface UuidInterface extends JsonSerializable, Serializable
      * @return DateTime A PHP DateTime representation of the date
      * @throws UnsupportedOperationException If this UUID is not a version 1 UUID
      * @throws UnsatisfiedDependencyException if called in a 32-bit system and
-     *     `Moontoast\Math\BigNumber` is not present
+     *     `Brick\Math\BigInteger` is not present
      */
     public function getDateTime();
 
@@ -137,7 +137,7 @@ interface UuidInterface extends JsonSerializable, Serializable
      * representation.
      *
      * @return mixed Converted representation of the unsigned 128-bit integer value
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+     * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
      */
     public function getInteger();
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -27,7 +27,7 @@ use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;
  *     changes.
  * @return string
  * @throws UnsatisfiedDependencyException if called on a 32-bit system and
- *     `Moontoast\Math\BigNumber` is not present
+ *     `Brick\Math\BigInteger` is not present
  * @throws InvalidArgumentException
  * @throws Exception if it was not possible to gather sufficient entropy
  */
@@ -54,7 +54,7 @@ function v3($ns, $name)
  * Generate a version 4 (random) UUID.
  *
  * @return string
- * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
+ * @throws UnsatisfiedDependencyException if `Brick\Math\BigInteger` is not present
  * @throws InvalidArgumentException
  * @throws Exception
  */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,18 +23,18 @@ class TestCase extends PhpUnitTestCase
         }
     }
 
-    protected function skipIfNoMoontoastMath()
+    protected function skipIfNoBrickMath()
     {
-        if (!$this->hasMoontoastMath()) {
+        if (!$this->hasBrickMath()) {
             $this->markTestSkipped(
-                'Skipping test that requires moontoast/math.'
+                'Skipping test that requires brick/math.'
             );
         }
     }
 
-    protected function hasMoontoastMath()
+    protected function hasBrickMath()
     {
-        return class_exists('Moontoast\\Math\\BigNumber');
+        return class_exists('Brick\\Math\\BigInteger');
     }
 
     protected function skipIfLittleEndianHost()

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -193,7 +193,7 @@ class UuidTest extends TestCase
      */
     public function testGetDateTime32Bit()
     {
-        $this->skipIfNoMoontoastMath();
+        $this->skipIfNoBrickMath();
         Uuid::setFactory(new UuidFactory(new FeatureSet(false, true)));
 
         // Check a recent date
@@ -296,11 +296,11 @@ class UuidTest extends TestCase
      */
     public function testGetLeastSignificantBits()
     {
-        $this->skipIfNoMoontoastMath();
+        $this->skipIfNoBrickMath();
 
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertInstanceOf('Moontoast\Math\BigNumber', $uuid->getLeastSignificantBits());
-        $this->assertEquals('11178224546741000806', $uuid->getLeastSignificantBits()->getValue());
+        $this->assertInstanceOf('Brick\Math\BigInteger', $uuid->getLeastSignificantBits());
+        $this->assertEquals('11178224546741000806', $uuid->getLeastSignificantBits());
     }
 
     /**
@@ -326,11 +326,11 @@ class UuidTest extends TestCase
      */
     public function testGetMostSignificantBits()
     {
-        $this->skipIfNoMoontoastMath();
+        $this->skipIfNoBrickMath();
 
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertInstanceOf('Moontoast\Math\BigNumber', $uuid->getMostSignificantBits());
-        $this->assertEquals('18406084892941947361', $uuid->getMostSignificantBits()->getValue());
+        $this->assertInstanceOf('Brick\Math\BigInteger', $uuid->getMostSignificantBits());
+        $this->assertEquals('18406084892941947361', $uuid->getMostSignificantBits());
     }
 
     /**
@@ -1059,7 +1059,7 @@ class UuidTest extends TestCase
      */
     public function testCalculateUuidTimeForce32BitPath()
     {
-        $this->skipIfNoMoontoastMath();
+        $this->skipIfNoBrickMath();
 
         $timeOfDay = new FixedTimeProvider([
             'sec' => 1348845514,
@@ -1151,7 +1151,7 @@ class UuidTest extends TestCase
      */
     public function testCalculateUuidTimeUpperLowerBounds64BitThrough32BitPath()
     {
-        $this->skipIfNoMoontoastMath();
+        $this->skipIfNoBrickMath();
         $this->skip64BitTest();
 
         $featureSet = new FeatureSet(false, true);
@@ -1199,7 +1199,7 @@ class UuidTest extends TestCase
      */
     public function testCalculateUuidTimeUpperLowerBounds32Bit()
     {
-        $this->skipIfNoMoontoastMath();
+        $this->skipIfNoBrickMath();
 
         // 2038-01-19T03:14:07+00:00
         $timeOfDay = new FixedTimeProvider([
@@ -1295,7 +1295,7 @@ class UuidTest extends TestCase
      */
     public function test32BitMatch64BitForOneHourPeriod()
     {
-        $this->skipIfNoMoontoastMath();
+        $this->skipIfNoBrickMath();
         $this->skip64BitTest();
 
         $currentTime = strtotime('2012-12-11T00:00:00+00:00');
@@ -1855,7 +1855,7 @@ class UuidTest extends TestCase
                 $this->assertEquals($test['string'], (string)$uuid);
                 $this->assertEquals($test['hex'], $uuid->getHex());
                 $this->assertEquals(base64_decode($test['bytes']), $uuid->getBytes());
-                if ($this->hasMoontoastMath()) {
+                if ($this->skipIfNoBrickMath()) {
                     $this->assertEquals($test['int'], (string)$uuid->getInteger());
                 }
                 $this->assertEquals($test['fields'], $uuid->getFieldsHex());

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -1541,7 +1541,7 @@ class UuidTest extends TestCase
     public function testFromIntegerString()
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $integer = $uuid->getInteger()->getValue();
+        $integer = $uuid->getInteger();
 
         $fromIntegerUuid = Uuid::fromInteger($integer);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Use the ``brick/math`` package for BigNumbers instead of the abandoned ``moontoast/math`` package.

## Description
<!--- Describe your changes in detail. -->
Replaced all ``Moontoast/Math/BigNumber`` usages with the ``Brick/Math/BigInteger`` variant.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change has been made since the currently used package will no longer be maintained according to the message on packagist.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this by running the provided PHPUnit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

I'm not sure in how far this is a breaking change. I tried to keep everything compatible like I kept the BigNumber name in the Converters instead of renaming them to i.e. BigIntegerTimeConverter although that would take more sense. As far as the package goes it does not support the getValue() function on BigIntegers but just passes the value in the __toString() function.

It does require a replacement of a package so does that qualify it for being breaking?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run-script test` locally, and there were no failures or errors.
