### PR TITLE
Added custom getValue() method for custom APIs

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -228,6 +228,17 @@ class Uuid implements UuidInterface
     {
         return $this->toString();
     }
+    
+    /**
+     * Converts this UUID object to a string. Needed for custom APIs which require
+     * an object here with 'value' field (e.g. FHIRResource::getId() in FHIR R4 medical standard).
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->toString();
+    }
 
     /**
      * Re-constructs the object from its serialized form.

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -1897,6 +1897,16 @@ class UuidTest extends TestCase
         $this->assertEquals('"' . $uuid->toString() . '"', json_encode($uuid));
     }
 
+    /**
+     * @covers Ramsey\Uuid\Uuid::getValue
+     */
+    public function testGetValue()
+    {
+        $uuid = Uuid::uuid1();
+
+        $this->assertEquals('"' . $uuid->getValue() . '"', json_encode($uuid));
+    }
+
     public function testSerialize()
     {
         $uuid = Uuid::uuid4();


### PR DESCRIPTION
Added custom getValue() method for custom APIs

## Description
There are no changes here really, just added an alias method.

## Motivation and context
In some APIs, id fields are objects, which when serialized, try to get ID values via a ```getValue()``` method. In such cases, since ```UUID::getValue()``` doesn't exist, we get stuck. Adding this method is easier compared to adding a workaround to such APIs. E.g. in medical standard FHIR/R4, id's are resources which have ```value``` field in them, with ```getValue()``` method attached. Unfortunately changing standards like this is literally impossible.

## How has this been tested?
It's an alias to an existing method, doesn't really need any testing.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run-script test` locally, and there were no failures or errors.
