### PR TITLE
Fix typo in TimestampFirstCombCodec

### DIFF
--- a/src/Codec/TimestampFirstCombCodec.php
+++ b/src/Codec/TimestampFirstCombCodec.php
@@ -17,7 +17,7 @@ use Ramsey\Uuid\Exception\InvalidUuidStringException;
 use Ramsey\Uuid\UuidInterface;
 
 /**
- * TimestampLastCombCodec encodes and decodes COMB UUIDs which have the timestamp as the first 48 bits.
+ * TimestampFirstCombCodec encodes and decodes COMB UUIDs which have the timestamp as the first 48 bits.
  * To be used with MySQL, PostgreSQL, Oracle.
  */
 class TimestampFirstCombCodec extends StringCodec


### PR DESCRIPTION
Just fixing a typo I've just seen in a phpdoc.

This PR doesn't change anything at all.
