### PR TITLE
Refining type of producing a `string` that can be declared as `non-empty-string`

### DIFF
--- a/src/Codec/CodecInterface.php
+++ b/src/Codec/CodecInterface.php
@@ -29,6 +29,8 @@ interface CodecInterface
      *
      * @return string Hexadecimal string representation of a UUID
      *
+     * @psalm-return non-empty-string
+     *
      * @psalm-pure
      */
     public function encode(UuidInterface $uuid): string;
@@ -40,6 +42,8 @@ interface CodecInterface
      *     representation
      *
      * @return string Binary string representation of a UUID
+     *
+     * @psalm-return non-empty-string
      *
      * @psalm-pure
      */

--- a/src/Codec/OrderedTimeCodec.php
+++ b/src/Codec/OrderedTimeCodec.php
@@ -46,6 +46,9 @@ class OrderedTimeCodec extends StringCodec
      *
      * @inheritDoc
      * @psalm-pure
+     * @psalm-return non-empty-string
+     * @psalm-suppress MoreSpecificReturnType we know that the retrieved `string` is never empty
+     * @psalm-suppress LessSpecificReturnStatement we know that the retrieved `string` is never empty
      */
     public function encodeBinary(UuidInterface $uuid): string
     {

--- a/src/Codec/StringCodec.php
+++ b/src/Codec/StringCodec.php
@@ -65,6 +65,9 @@ class StringCodec implements CodecInterface
 
     /**
      * @psalm-pure
+     * @psalm-return non-empty-string
+     * @psalm-suppress MoreSpecificReturnType we know that the retrieved `string` is never empty
+     * @psalm-suppress LessSpecificReturnStatement we know that the retrieved `string` is never empty
      */
     public function encodeBinary(UuidInterface $uuid): string
     {

--- a/src/Codec/TimestampFirstCombCodec.php
+++ b/src/Codec/TimestampFirstCombCodec.php
@@ -45,6 +45,9 @@ class TimestampFirstCombCodec extends StringCodec
 {
     /**
      * @psalm-pure
+     * @psalm-return non-empty-string
+     * @psalm-suppress MoreSpecificReturnType we know that the retrieved `string` is never empty
+     * @psalm-suppress LessSpecificReturnStatement we know that the retrieved `string` is never empty
      */
     public function encode(UuidInterface $uuid): string
     {
@@ -62,6 +65,9 @@ class TimestampFirstCombCodec extends StringCodec
 
     /**
      * @psalm-pure
+     * @psalm-return non-empty-string
+     * @psalm-suppress MoreSpecificReturnType we know that the retrieved `string` is never empty
+     * @psalm-suppress LessSpecificReturnStatement we know that the retrieved `string` is never empty
      */
     public function encodeBinary(UuidInterface $uuid): string
     {

--- a/src/Converter/Number/GenericNumberConverter.php
+++ b/src/Converter/Number/GenericNumberConverter.php
@@ -37,6 +37,9 @@ class GenericNumberConverter implements NumberConverterInterface
     /**
      * @inheritDoc
      * @psalm-pure
+     * @psalm-return numeric-string
+     * @psalm-suppress MoreSpecificReturnType we know that the retrieved `string` is never empty
+     * @psalm-suppress LessSpecificReturnStatement we know that the retrieved `string` is never empty
      */
     public function fromHex(string $hex): string
     {
@@ -46,6 +49,9 @@ class GenericNumberConverter implements NumberConverterInterface
     /**
      * @inheritDoc
      * @psalm-pure
+     * @psalm-return non-empty-string
+     * @psalm-suppress MoreSpecificReturnType we know that the retrieved `string` is never empty
+     * @psalm-suppress LessSpecificReturnStatement we know that the retrieved `string` is never empty
      */
     public function toHex(string $number): string
     {

--- a/src/Converter/NumberConverterInterface.php
+++ b/src/Converter/NumberConverterInterface.php
@@ -31,6 +31,8 @@ interface NumberConverterInterface
      *
      * @return string String representation of an integer
      *
+     * @psalm-return numeric-string
+     *
      * @psalm-pure
      */
     public function fromHex(string $hex): string;
@@ -44,6 +46,8 @@ interface NumberConverterInterface
      *     than PHP_INT_MAX.
      *
      * @return string Hexadecimal string
+     *
+     * @psalm-return non-empty-string
      *
      * @psalm-pure
      */

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -226,6 +226,7 @@ class Uuid implements UuidInterface
         $this->timeConverter = $timeConverter;
     }
 
+    /** @psalm-return non-empty-string */
     public function __toString(): string
     {
         return $this->toString();
@@ -288,6 +289,7 @@ class Uuid implements UuidInterface
         return $this->compareTo($other) === 0;
     }
 
+    /** @psalm-return non-empty-string */
     public function getBytes(): string
     {
         return $this->codec->encodeBinary($this);
@@ -298,16 +300,23 @@ class Uuid implements UuidInterface
         return $this->fields;
     }
 
+    /**
+     * @psalm-return non-empty-string
+     * @psalm-suppress MoreSpecificReturnType we know that the retrieved `string` is never empty
+     * @psalm-suppress LessSpecificReturnStatement we know that the retrieved `string` is never empty
+     */
     public function getHex(): string
     {
         return str_replace('-', '', $this->toString());
     }
 
+    /** @psalm-return non-empty-string */
     public function getInteger(): string
     {
         return $this->numberConverter->fromHex($this->getHex());
     }
 
+    /** @psalm-return non-empty-string */
     public function toString(): string
     {
         return $this->codec->encode($this);

--- a/src/UuidInterface.php
+++ b/src/UuidInterface.php
@@ -61,6 +61,8 @@ interface UuidInterface extends
 
     /**
      * Returns the binary string representation of the UUID
+     *
+     * @psalm-return non-empty-string
      */
     public function getBytes(): string;
 
@@ -71,21 +73,29 @@ interface UuidInterface extends
 
     /**
      * Returns the hexadecimal string representation of the UUID
+     *
+     * @psalm-return non-empty-string
      */
     public function getHex(): string;
 
     /**
      * Returns the integer value of the UUID as a string
+     *
+     * @psalm-return non-empty-string
      */
     public function getInteger(): string;
 
     /**
      * Returns a string representation of the UUID
+     *
+     * @psalm-return non-empty-string
      */
     public function toString(): string;
 
     /**
      * Casts the UUID to a string representation
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string;
 }

--- a/tests/static-analysis/UuidIsNeverEmpty.php
+++ b/tests/static-analysis/UuidIsNeverEmpty.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the ramsey/uuid library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace Ramsey\Uuid\StaticAnalysis;
+
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * This is a static analysis fixture to verify that the API signature
+ * of a UUID does not return empty strings for methods that never will do so.
+ */
+final class UuidIsNeverEmpty
+{
+    /** @psalm-return non-empty-string */
+    public function bytesAreNeverEmpty(UuidInterface $uuid): string
+    {
+        return $uuid->getBytes();
+    }
+
+    /** @psalm-return non-empty-string */
+    public function hexIsNeverEmpty(UuidInterface $uuid): string
+    {
+        return $uuid->getHex();
+    }
+
+    /** @psalm-return non-empty-string */
+    public function integerIsNeverEmpty(UuidInterface $uuid): string
+    {
+        return $uuid->getInteger();
+    }
+
+    /** @psalm-return non-empty-string */
+    public function stringIsNeverEmpty(UuidInterface $uuid): string
+    {
+        return $uuid->toString();
+    }
+}


### PR DESCRIPTION
## Motivation and context

Overall, we know that a UUID can never be an empty string, hex, or numeric string. Even the zero-case is `'0'` in hex/int stringy form.

This patch formalizes that, allowing consumers of `UuidInterface` to rely on the fact that the produced `string` will never be empty.

## How has this been tested?

Additional static-analysis tests were introduced: they just check variance.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] ~~My change requires a change to the documentation.~~
- [x] ~~I have updated the documentation accordingly.~~
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run-script test` locally, and there were no failures or errors.
