### PR TITLE
Marking `Uuid::uuid5()` as pure: same input leads to same output, and no I/O under normal operational constraints

### DIFF
--- a/src/Builder/DegradedUuidBuilder.php
+++ b/src/Builder/DegradedUuidBuilder.php
@@ -61,6 +61,8 @@ class DegradedUuidBuilder implements UuidBuilderInterface
      * @param string $bytes The byte string from which to construct a UUID
      *
      * @return DegradedUuid The DegradedUuidBuild returns an instance of Ramsey\Uuid\DegradedUuid
+     *
+     * @psalm-pure
      */
     public function build(CodecInterface $codec, string $bytes): UuidInterface
     {

--- a/src/Builder/FallbackBuilder.php
+++ b/src/Builder/FallbackBuilder.php
@@ -48,6 +48,8 @@ class FallbackBuilder implements UuidBuilderInterface
      * @param string $bytes The byte string from which to construct a UUID
      *
      * @return UuidInterface an instance of a UUID object
+     *
+     * @psalm-pure
      */
     public function build(CodecInterface $codec, string $bytes): UuidInterface
     {

--- a/src/Builder/UuidBuilderInterface.php
+++ b/src/Builder/UuidBuilderInterface.php
@@ -32,6 +32,8 @@ interface UuidBuilderInterface
      *
      * @return UuidInterface Implementations may choose to return more specific
      *     instances of UUIDs that implement UuidInterface
+     *
+     * @psalm-pure
      */
     public function build(CodecInterface $codec, string $bytes): UuidInterface;
 }

--- a/src/Generator/DefaultNameGenerator.php
+++ b/src/Generator/DefaultNameGenerator.php
@@ -25,6 +25,7 @@ use function hash;
  */
 class DefaultNameGenerator implements NameGeneratorInterface
 {
+    /** @psalm-pure */
     public function generate(UuidInterface $ns, string $name, string $hashAlgorithm): string
     {
         /** @var string|bool $bytes */

--- a/src/Generator/NameGeneratorInterface.php
+++ b/src/Generator/NameGeneratorInterface.php
@@ -31,6 +31,8 @@ interface NameGeneratorInterface
      * @param string $hashAlgorithm The hashing algorithm to use
      *
      * @return string A binary string
+     *
+     * @psalm-pure
      */
     public function generate(UuidInterface $ns, string $name, string $hashAlgorithm): string;
 }

--- a/src/Generator/PeclUuidNameGenerator.php
+++ b/src/Generator/PeclUuidNameGenerator.php
@@ -30,6 +30,7 @@ use function uuid_parse;
  */
 class PeclUuidNameGenerator implements NameGeneratorInterface
 {
+    /** @psalm-pure */
     public function generate(UuidInterface $ns, string $name, string $hashAlgorithm): string
     {
         switch ($hashAlgorithm) {

--- a/src/Guid/GuidBuilder.php
+++ b/src/Guid/GuidBuilder.php
@@ -62,6 +62,8 @@ class GuidBuilder implements UuidBuilderInterface
      * @param string $bytes The byte string from which to construct a UUID
      *
      * @return Guid The GuidBuilder returns an instance of Ramsey\Uuid\Guid\Guid
+     *
+     * @psalm-pure
      */
     public function build(CodecInterface $codec, string $bytes): UuidInterface
     {

--- a/src/Nonstandard/UuidBuilder.php
+++ b/src/Nonstandard/UuidBuilder.php
@@ -61,6 +61,8 @@ class UuidBuilder implements UuidBuilderInterface
      *
      * @return Uuid The Nonstandard\UuidBuilder returns an instance of
      *     Nonstandard\Uuid
+     *
+     * @psalm-pure
      */
     public function build(CodecInterface $codec, string $bytes): UuidInterface
     {

--- a/src/Rfc4122/UuidBuilder.php
+++ b/src/Rfc4122/UuidBuilder.php
@@ -65,6 +65,8 @@ class UuidBuilder implements UuidBuilderInterface
      * @param string $bytes The byte string from which to construct a UUID
      *
      * @return Rfc4122UuidInterface UuidBuilder returns instances of Rfc4122UuidInterface
+     *
+     * @psalm-pure
      */
     public function build(CodecInterface $codec, string $bytes): UuidInterface
     {

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -538,6 +538,9 @@ class Uuid implements UuidInterface
      *
      * @return UuidInterface A UuidInterface instance that represents a
      *     version 5 UUID
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function uuid5($ns, string $name): UuidInterface
     {

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -512,6 +512,9 @@ class Uuid implements UuidInterface
      *
      * @return UuidInterface A UuidInterface instance that represents a
      *     version 3 UUID
+     *
+     * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
+     *             but under constant factory setups, this method operates in functionally pure manners
      */
     public static function uuid3($ns, string $name): UuidInterface
     {

--- a/src/UuidFactory.php
+++ b/src/UuidFactory.php
@@ -351,6 +351,7 @@ class UuidFactory implements UuidFactoryInterface
 
     /**
      * @inheritDoc
+     * @psalm-pure
      */
     public function uuid3($ns, string $name): UuidInterface
     {
@@ -366,6 +367,7 @@ class UuidFactory implements UuidFactoryInterface
 
     /**
      * @inheritDoc
+     * @psalm-pure
      */
     public function uuid5($ns, string $name): UuidInterface
     {
@@ -401,6 +403,8 @@ class UuidFactory implements UuidFactoryInterface
      *
      * @return UuidInterface An instance of UuidInterface, created from the
      *     provided bytes
+     *
+     * @psalm-pure
      */
     public function uuid(string $bytes): UuidInterface
     {
@@ -418,6 +422,8 @@ class UuidFactory implements UuidFactoryInterface
      *
      * @return UuidInterface An instance of UuidInterface, created by hashing
      *     together the provided namespace and name
+     *
+     * @psalm-pure
      */
     private function uuidFromNsAndName($ns, string $name, int $version, string $hashAlgorithm): UuidInterface
     {
@@ -438,6 +444,8 @@ class UuidFactory implements UuidFactoryInterface
      *
      * @return UuidInterface An instance of UuidInterface, created from the
      *     byte string and version
+     *
+     * @psalm-pure
      */
     private function uuidFromBytesAndVersion(string $bytes, int $version): UuidInterface
     {

--- a/src/UuidFactoryInterface.php
+++ b/src/UuidFactoryInterface.php
@@ -83,6 +83,8 @@ interface UuidFactoryInterface
      *
      * @return UuidInterface A UuidInterface instance that represents a
      *     version 3 UUID
+     *
+     * @psalm-pure
      */
     public function uuid3($ns, string $name): UuidInterface;
 
@@ -103,6 +105,8 @@ interface UuidFactoryInterface
      *
      * @return UuidInterface A UuidInterface instance that represents a
      *     version 5 UUID
+     *
+     * @psalm-pure
      */
     public function uuid5($ns, string $name): UuidInterface;
 

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.8.3@389af1bfc739bfdff3f9e3dc7bd6499aee51a831">
+<files psalm-version="3.9.4@352bd3f5c5789db04e4010856c2f4e01ed354f4e">
   <file src="src/Builder/DegradedUuidBuilder.php">
     <DeprecatedClass occurrences="3">
       <code>new DegradedTimeConverter()</code>
@@ -44,6 +44,13 @@
       <code>uuid_parse($uuid)</code>
     </MixedReturnStatement>
   </file>
+  <file src="src/Generator/PeclUuidNameGenerator.php">
+    <ImpureFunctionCall occurrences="3">
+      <code>uuid_generate_md5</code>
+      <code>uuid_generate_sha1</code>
+      <code>uuid_parse</code>
+    </ImpureFunctionCall>
+  </file>
   <file src="src/Provider/Dce/SystemDceSecurityProvider.php">
     <ForbiddenCode occurrences="5">
       <code>shell_exec('id -u')</code>
@@ -54,23 +61,16 @@
     </ForbiddenCode>
   </file>
   <file src="src/Provider/Node/SystemNodeProvider.php">
-    <MixedArgument occurrences="2">
-      <code>$node</code>
+    <MixedArgument occurrences="1">
       <code>$macs</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$node</code>
+    <MixedAssignment occurrences="1">
       <code>$node</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>getNode</code>
-    </MixedInferredReturnType>
-    <TypeDoesNotContainType occurrences="1">
-      <code>is_array($node)</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="src/Uuid.php">
-    <ImpureMethodCall occurrences="5">
+    <ImpureMethodCall occurrences="6">
+      <code>getFactory</code>
       <code>getFactory</code>
       <code>getFactory</code>
       <code>getFactory</code>

--- a/tests/static-analysis/UuidIsImmutable.php
+++ b/tests/static-analysis/UuidIsImmutable.php
@@ -91,6 +91,15 @@ final class UuidIsImmutable
     }
 
     /** @psalm-pure */
+    public static function uuid3IsPure(): UuidInterface
+    {
+        return Uuid::uuid3(
+            Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66'),
+            'Look ma! I am a pure function!'
+        );
+    }
+
+    /** @psalm-pure */
     public static function uuid5IsPure(): UuidInterface
     {
         return Uuid::uuid5(

--- a/tests/static-analysis/UuidIsImmutable.php
+++ b/tests/static-analysis/UuidIsImmutable.php
@@ -89,4 +89,13 @@ final class UuidIsImmutable
             Uuid::isValid('ff6f8cb0-c57d-11e1-9b21-0800200c9a66'),
         ];
     }
+
+    /** @psalm-pure */
+    public static function uuid5IsPure(): UuidInterface
+    {
+        return Uuid::uuid5(
+            Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66'),
+            'Look ma! I am a pure function!'
+        );
+    }
 }


### PR DESCRIPTION
## Description

`Uuid::uuid5()` can be safely used within the context of pure functions, as it guarantees same output for same parameters.

## How has this been tested?

Added static analysis tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run-script test` locally, and there were no failures or errors.
