### PR TITLE
Fixed static methods invoked as instance methods

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -41,7 +41,7 @@ create a regular UuidV1 instance and pass it.
         $uuid = Uuid::uuid1();
         $myObj = new MyClass();
 
-        $this->assertIsString($myObj->tellTime($uuid));
+        self::assertIsString($myObj->tellTime($uuid));
     }
 
 This might satisfy our testing needs if we only want to assert that the method
@@ -58,7 +58,7 @@ by generating a UUID ahead of time and using it as a known value.
         $uuid = Uuid::fromString('177ef0d8-6630-11ea-b69a-0242ac130003');
         $myObj = new MyClass();
 
-        $this->assertSame('2020-03-14 20:12:12', $myObj->tellTime($uuid));
+        self::assertSame('2020-03-14 20:12:12', $myObj->tellTime($uuid));
     }
 
 .. note::
@@ -129,10 +129,10 @@ and we can even change the value returned by the :php:meth:`uuid1()
         $myObj = new MyClass();
 
         $factory->uuid1 = Uuid::fromString('177ef0d8-6630-11ea-b69a-0242ac130003');
-        $this->assertSame('2020-03-14 20:12:12', $myObj->tellTime());
+        self::assertSame('2020-03-14 20:12:12', $myObj->tellTime());
 
         $factory->uuid1 = Uuid::fromString('13814000-1dd2-11b2-9669-00007ffffffe');
-        $this->assertSame('1970-01-01 00:00:00', $myObj->tellTime());
+        self::assertSame('1970-01-01 00:00:00', $myObj->tellTime());
     }
 
 .. attention::
@@ -184,7 +184,7 @@ object were called.
 
         $myObj = new MyClass();
 
-        $this->assertSame('a test date', $myObj->tellTime($uuid));
+        self::assertSame('a test date', $myObj->tellTime($uuid));
     }
 
 .. note::

--- a/tests/BinaryUtilsTest.php
+++ b/tests/BinaryUtilsTest.php
@@ -15,8 +15,8 @@ class BinaryUtilsTest extends TestCase
      */
     public function testApplyVersion(int $timeHi, int $version, int $expectedInt, string $expectedHex): void
     {
-        $this->assertSame($expectedInt, BinaryUtils::applyVersion($timeHi, $version));
-        $this->assertSame($expectedHex, dechex(BinaryUtils::applyVersion($timeHi, $version)));
+        self::assertSame($expectedInt, BinaryUtils::applyVersion($timeHi, $version));
+        self::assertSame($expectedHex, dechex(BinaryUtils::applyVersion($timeHi, $version)));
     }
 
     /**
@@ -24,8 +24,8 @@ class BinaryUtilsTest extends TestCase
      */
     public function testApplyVariant(int $clockSeq, int $expectedInt, string $expectedHex): void
     {
-        $this->assertSame($expectedInt, BinaryUtils::applyVariant($clockSeq));
-        $this->assertSame($expectedHex, dechex(BinaryUtils::applyVariant($clockSeq)));
+        self::assertSame($expectedInt, BinaryUtils::applyVariant($clockSeq));
+        self::assertSame($expectedHex, dechex(BinaryUtils::applyVariant($clockSeq)));
     }
 
     /**

--- a/tests/Builder/DefaultUuidBuilderTest.php
+++ b/tests/Builder/DefaultUuidBuilderTest.php
@@ -37,6 +37,6 @@ class DefaultUuidBuilderTest extends TestCase
         $bytes = (string) hex2bin(implode('', $fields));
 
         $result = $builder->build($codec, $bytes);
-        $this->assertInstanceOf(Uuid::class, $result);
+        self::assertInstanceOf(Uuid::class, $result);
     }
 }

--- a/tests/Builder/FallbackBuilderTest.php
+++ b/tests/Builder/FallbackBuilderTest.php
@@ -101,19 +101,19 @@ class FallbackBuilderTest extends TestCase
         /** @var BuilderCollection $unserializedBuilderCollection */
         $unserializedBuilderCollection = unserialize($serializedBuilderCollection);
 
-        $this->assertInstanceOf(BuilderCollection::class, $unserializedBuilderCollection);
+        self::assertInstanceOf(BuilderCollection::class, $unserializedBuilderCollection);
 
         /** @var UuidBuilderInterface $builder */
         foreach ($unserializedBuilderCollection as $builder) {
             $codec = new StringCodec($builder);
 
-            $this->assertInstanceOf(UuidBuilderInterface::class, $builder);
+            self::assertInstanceOf(UuidBuilderInterface::class, $builder);
 
             try {
                 $uuid = $builder->build($codec, $bytes);
 
                 if (($uuid instanceof UuidV1) || ($uuid instanceof UuidV2) || ($uuid instanceof UuidV6)) {
-                    $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+                    self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
                 }
             } catch (UnableToBuildUuidException $exception) {
                 switch ($exception->getMessage()) {

--- a/tests/Codec/GuidStringCodecTest.php
+++ b/tests/Codec/GuidStringCodecTest.php
@@ -52,7 +52,7 @@ class GuidStringCodecTest extends TestCase
 
     public function testEncodeUsesFieldsArray(): void
     {
-        $this->uuid->expects($this->once())
+        $this->uuid->expects(self::once())
             ->method('getFields')
             ->willReturn($this->fields);
         $codec = new GuidStringCodec($this->builder);
@@ -65,7 +65,7 @@ class GuidStringCodecTest extends TestCase
             ->willReturn($this->fields);
         $codec = new GuidStringCodec($this->builder);
         $result = $codec->encode($this->uuid);
-        $this->assertSame('12345678-1234-4bcd-abef-1234abcd4321', $result);
+        self::assertSame('12345678-1234-4bcd-abef-1234abcd4321', $result);
     }
 
     public function testEncodeBinary(): void
@@ -81,7 +81,7 @@ class GuidStringCodecTest extends TestCase
 
         $bytes = $codec->encodeBinary($uuid);
 
-        $this->assertSame($expectedBytes, $bytes);
+        self::assertSame($expectedBytes, $bytes);
     }
 
     public function testDecodeReturnsGuid(): void
@@ -94,8 +94,8 @@ class GuidStringCodecTest extends TestCase
         $codec = new GuidStringCodec($builder);
         $guid = $codec->decode($string);
 
-        $this->assertInstanceOf(Guid::class, $guid);
-        $this->assertSame('12345678-1234-4bcd-abef-1234abcd4321', $guid->toString());
+        self::assertInstanceOf(Guid::class, $guid);
+        self::assertSame('12345678-1234-4bcd-abef-1234abcd4321', $guid->toString());
     }
 
     public function testDecodeReturnsUuidFromBuilder(): void
@@ -106,7 +106,7 @@ class GuidStringCodecTest extends TestCase
 
         $codec = new GuidStringCodec($this->builder);
         $result = $codec->decode($string);
-        $this->assertSame($this->uuid, $result);
+        self::assertSame($this->uuid, $result);
     }
 
     public function testDecodeBytesReturnsUuid(): void
@@ -117,6 +117,6 @@ class GuidStringCodecTest extends TestCase
         $this->builder->method('build')
             ->willReturn($this->uuid);
         $result = $codec->decodeBytes($bytes);
-        $this->assertSame($this->uuid, $result);
+        self::assertSame($this->uuid, $result);
     }
 }

--- a/tests/Codec/OrderedTimeCodecTest.php
+++ b/tests/Codec/OrderedTimeCodecTest.php
@@ -70,7 +70,7 @@ class OrderedTimeCodecTest extends TestCase
 
     public function testEncodeUsesFieldsArray(): void
     {
-        $this->uuid->expects($this->once())
+        $this->uuid->expects(self::once())
             ->method('getFields')
             ->willReturn($this->fields);
         $codec = new OrderedTimeCodec($this->builder);
@@ -83,7 +83,7 @@ class OrderedTimeCodecTest extends TestCase
             ->willReturn($this->fields);
         $codec = new OrderedTimeCodec($this->builder);
         $result = $codec->encode($this->uuid);
-        $this->assertSame($this->uuidString, $result);
+        self::assertSame($this->uuidString, $result);
     }
 
     public function testEncodeBinary(): void
@@ -100,7 +100,7 @@ class OrderedTimeCodecTest extends TestCase
 
         $uuid = $factory->fromString($this->uuidString);
 
-        $this->assertSame($expected, $codec->encodeBinary($uuid));
+        self::assertSame($expected, $codec->encodeBinary($uuid));
     }
 
     public function testDecodeBytesThrowsExceptionWhenBytesStringNotSixteenCharacters(): void
@@ -121,7 +121,7 @@ class OrderedTimeCodecTest extends TestCase
             ->willReturn($this->uuid);
         $codec = new OrderedTimeCodec($this->builder);
         $result = $codec->decode($string);
-        $this->assertSame($this->uuid, $result);
+        self::assertSame($this->uuid, $result);
     }
 
     public function testDecodeBytesRearrangesFields(): void
@@ -140,7 +140,7 @@ class OrderedTimeCodecTest extends TestCase
         $expectedUuid = $factory->fromString($this->uuidString);
         $uuidReturned = $codec->decodeBytes($bytes);
 
-        $this->assertTrue($uuidReturned->equals($expectedUuid));
+        self::assertTrue($uuidReturned->equals($expectedUuid));
     }
 
     public function testEncodeBinaryThrowsExceptionForNonRfc4122Uuid(): void

--- a/tests/Codec/StringCodecTest.php
+++ b/tests/Codec/StringCodecTest.php
@@ -55,7 +55,7 @@ class StringCodecTest extends TestCase
 
     public function testEncodeUsesFieldsArray(): void
     {
-        $this->uuid->expects($this->once())
+        $this->uuid->expects(self::once())
             ->method('getFields')
             ->willReturn($this->fields);
         $codec = new StringCodec($this->builder);
@@ -68,7 +68,7 @@ class StringCodecTest extends TestCase
             ->willReturn($this->fields);
         $codec = new StringCodec($this->builder);
         $result = $codec->encode($this->uuid);
-        $this->assertSame($this->uuidString, $result);
+        self::assertSame($this->uuidString, $result);
     }
 
     public function testEncodeBinaryReturnsBinaryString(): void
@@ -83,7 +83,7 @@ class StringCodecTest extends TestCase
 
         $codec = new StringCodec($this->builder);
         $result = $codec->encodeBinary($this->uuid);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function testDecodeUsesBuilderOnFields(): void
@@ -100,9 +100,9 @@ class StringCodecTest extends TestCase
         $bytes = hex2bin(implode('', $fields));
 
         $string = 'uuid:12345678-1234-4bcd-abef-1234abcd4321';
-        $this->builder->expects($this->once())
+        $this->builder->expects(self::once())
             ->method('build')
-            ->with($this->isInstanceOf(StringCodec::class), $bytes);
+            ->with(self::isInstanceOf(StringCodec::class), $bytes);
         $codec = new StringCodec($this->builder);
         $codec->decode($string);
     }
@@ -123,7 +123,7 @@ class StringCodecTest extends TestCase
             ->willReturn($this->uuid);
         $codec = new StringCodec($this->builder);
         $result = $codec->decode($string);
-        $this->assertSame($this->uuid, $result);
+        self::assertSame($this->uuid, $result);
     }
 
     public function testDecodeBytesThrowsExceptionWhenBytesStringNotSixteenCharacters(): void
@@ -145,6 +145,6 @@ class StringCodecTest extends TestCase
         $this->builder->method('build')
             ->willReturn($this->uuid);
         $result = $codec->decodeBytes($bytes);
-        $this->assertSame($this->uuid, $result);
+        self::assertSame($this->uuid, $result);
     }
 }

--- a/tests/Converter/Number/BigNumberConverterTest.php
+++ b/tests/Converter/Number/BigNumberConverterTest.php
@@ -37,13 +37,13 @@ class BigNumberConverterTest extends TestCase
     {
         $converter = new BigNumberConverter();
 
-        $this->assertSame('65535', $converter->fromHex('ffff'));
+        self::assertSame('65535', $converter->fromHex('ffff'));
     }
 
     public function testToHex(): void
     {
         $converter = new BigNumberConverter();
 
-        $this->assertSame('ffff', $converter->toHex('65535'));
+        self::assertSame('ffff', $converter->toHex('65535'));
     }
 }

--- a/tests/Converter/Number/GenericNumberConverterTest.php
+++ b/tests/Converter/Number/GenericNumberConverterTest.php
@@ -15,7 +15,7 @@ class GenericNumberConverterTest extends TestCase
         $calculator = new BrickMathCalculator();
         $converter = new GenericNumberConverter($calculator);
 
-        $this->assertSame('65535', $converter->fromHex('ffff'));
+        self::assertSame('65535', $converter->fromHex('ffff'));
     }
 
     public function testToHex(): void
@@ -23,6 +23,6 @@ class GenericNumberConverterTest extends TestCase
         $calculator = new BrickMathCalculator();
         $converter = new GenericNumberConverter($calculator);
 
-        $this->assertSame('ffff', $converter->toHex('65535'));
+        self::assertSame('ffff', $converter->toHex('65535'));
     }
 }

--- a/tests/Converter/Time/BigNumberTimeConverterTest.php
+++ b/tests/Converter/Time/BigNumberTimeConverterTest.php
@@ -35,8 +35,8 @@ class BigNumberTimeConverterTest extends TestCase
         $converter = new BigNumberTimeConverter();
         $returned = $converter->calculateTime((string) $seconds, (string) $microseconds);
 
-        $this->assertInstanceOf(Hexadecimal::class, $returned);
-        $this->assertSame($expected, $returned->toString());
+        self::assertInstanceOf(Hexadecimal::class, $returned);
+        self::assertSame($expected, $returned->toString());
     }
 
     public function testConvertTime(): void
@@ -44,7 +44,7 @@ class BigNumberTimeConverterTest extends TestCase
         $converter = new BigNumberTimeConverter();
         $returned = $converter->convertTime(new Hexadecimal('1e1c57dff6f8cb0'));
 
-        $this->assertSame('1341368074', $returned->getSeconds()->toString());
+        self::assertSame('1341368074', $returned->getSeconds()->toString());
     }
 
     public function testCalculateTimeThrowsExceptionWhenSecondsIsNotOnlyDigits(): void

--- a/tests/Converter/Time/GenericTimeConverterTest.php
+++ b/tests/Converter/Time/GenericTimeConverterTest.php
@@ -21,7 +21,7 @@ class GenericTimeConverterTest extends TestCase
 
         $result = $converter->calculateTime($seconds, $microseconds);
 
-        $this->assertSame($expected, $result->toString());
+        self::assertSame($expected, $result->toString());
     }
 
     /**
@@ -89,8 +89,8 @@ class GenericTimeConverterTest extends TestCase
 
         $result = $converter->convertTime($uuidTimestamp);
 
-        $this->assertSame($unixTimestamp, $result->getSeconds()->toString());
-        $this->assertSame($microseconds, $result->getMicroseconds()->toString());
+        self::assertSame($unixTimestamp, $result->getSeconds()->toString());
+        self::assertSame($microseconds, $result->getMicroseconds()->toString());
     }
 
     /**

--- a/tests/Converter/Time/PhpTimeConverterTest.php
+++ b/tests/Converter/Time/PhpTimeConverterTest.php
@@ -38,7 +38,7 @@ class PhpTimeConverterTest extends TestCase
         $converter = new PhpTimeConverter();
         $returned = $converter->calculateTime((string) $seconds, (string) $microseconds);
 
-        $this->assertSame($expected, $returned->toString());
+        self::assertSame($expected, $returned->toString());
     }
 
     public function testCalculateTimeThrowsExceptionWhenSecondsIsNotOnlyDigits(): void
@@ -80,8 +80,8 @@ class PhpTimeConverterTest extends TestCase
 
         $result = $converter->convertTime($uuidTimestamp);
 
-        $this->assertSame($unixTimestamp, $result->getSeconds()->toString());
-        $this->assertSame($microseconds, $result->getMicroseconds()->toString());
+        self::assertSame($unixTimestamp, $result->getSeconds()->toString());
+        self::assertSame($microseconds, $result->getMicroseconds()->toString());
     }
 
     /**
@@ -144,7 +144,7 @@ class PhpTimeConverterTest extends TestCase
 
         $result = $converter->calculateTime($seconds, $microseconds);
 
-        $this->assertSame($expected, $result->toString());
+        self::assertSame($expected, $result->toString());
     }
 
     /**

--- a/tests/DeprecatedUuidMethodsTraitTest.php
+++ b/tests/DeprecatedUuidMethodsTraitTest.php
@@ -31,9 +31,9 @@ class DeprecatedUuidMethodsTraitTest extends TestCase
 
         $uuid = new Uuid($fields, $numberConverter, $codec, $timeConverter);
 
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('2012-07-04T02:14:34+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('1341368074.491000', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('2012-07-04T02:14:34+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('1341368074.491000', $uuid->getDateTime()->format('U.u'));
     }
 
     public function testGetDateTimeThrowsException(): void

--- a/tests/Encoder/TimestampFirstCombCodecTest.php
+++ b/tests/Encoder/TimestampFirstCombCodecTest.php
@@ -44,7 +44,7 @@ class TimestampFirstCombCodecTest extends TestCase
 
         $encodedUuid = $this->codec->encode($uuidMock);
 
-        $this->assertSame('0800200c-9a66-11e1-9b21-ff6f8cb0c57d', $encodedUuid);
+        self::assertSame('0800200c-9a66-11e1-9b21-ff6f8cb0c57d', $encodedUuid);
     }
 
     public function testBinaryEncoding(): void
@@ -57,12 +57,12 @@ class TimestampFirstCombCodecTest extends TestCase
 
         $encodedUuid = $this->codec->encodeBinary($uuidMock);
 
-        $this->assertSame(hex2bin('0800200c9a6611e19b21ff6f8cb0c57d'), $encodedUuid);
+        self::assertSame(hex2bin('0800200c9a6611e19b21ff6f8cb0c57d'), $encodedUuid);
     }
 
     public function testDecoding(): void
     {
-        $this->builderMock->expects($this->exactly(1))
+        $this->builderMock->expects(self::exactly(1))
             ->method('build')
             ->with(
                 $this->codec,
@@ -80,7 +80,7 @@ class TimestampFirstCombCodecTest extends TestCase
 
     public function testBinaryDecoding(): void
     {
-        $this->builderMock->expects($this->exactly(1))
+        $this->builderMock->expects(self::exactly(1))
             ->method('build')
             ->with(
                 $this->codec,

--- a/tests/Encoder/TimestampLastCombCodecTest.php
+++ b/tests/Encoder/TimestampLastCombCodecTest.php
@@ -45,7 +45,7 @@ class TimestampLastCombCodecTest extends TestCase
 
         $encodedUuid = $this->codec->encode($uuidMock);
 
-        $this->assertSame('0800200c-9a66-11e1-9b21-ff6f8cb0c57d', $encodedUuid);
+        self::assertSame('0800200c-9a66-11e1-9b21-ff6f8cb0c57d', $encodedUuid);
     }
 
     public function testBinaryEncoding(): void
@@ -56,16 +56,16 @@ class TimestampLastCombCodecTest extends TestCase
 
         /** @var MockObject & UuidInterface $uuidMock */
         $uuidMock = $this->getMockBuilder(UuidInterface::class)->getMock();
-        $uuidMock->expects($this->any())->method('getFields')->willReturn($fields);
+        $uuidMock->expects(self::any())->method('getFields')->willReturn($fields);
 
         $encodedUuid = $this->codec->encodeBinary($uuidMock);
 
-        $this->assertSame(hex2bin('0800200c9a6611e19b21ff6f8cb0c57d'), $encodedUuid);
+        self::assertSame(hex2bin('0800200c9a6611e19b21ff6f8cb0c57d'), $encodedUuid);
     }
 
     public function testDecoding(): void
     {
-        $this->builderMock->expects($this->exactly(1))
+        $this->builderMock->expects(self::exactly(1))
             ->method('build')
             ->with(
                 $this->codec,
@@ -83,7 +83,7 @@ class TimestampLastCombCodecTest extends TestCase
 
     public function testBinaryDecoding(): void
     {
-        $this->builderMock->expects($this->exactly(1))
+        $this->builderMock->expects(self::exactly(1))
             ->method('build')
             ->with(
                 $this->codec,

--- a/tests/ExpectedBehaviorTest.php
+++ b/tests/ExpectedBehaviorTest.php
@@ -40,38 +40,38 @@ class ExpectedBehaviorTest extends TestCase
     {
         $uuid = call_user_func_array(['Ramsey\Uuid\Uuid', $method], $args);
 
-        $this->assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
-        $this->assertIsInt($uuid->compareTo(Uuid::uuid1()));
-        $this->assertNotSame(0, $uuid->compareTo(Uuid::uuid4()));
-        $this->assertSame(0, $uuid->compareTo(clone $uuid));
-        $this->assertFalse($uuid->equals(new stdClass()));
-        $this->assertTrue($uuid->equals(clone $uuid));
-        $this->assertIsString($uuid->getBytes());
-        $this->assertInstanceOf('Ramsey\Uuid\Converter\NumberConverterInterface', $uuid->getNumberConverter());
-        $this->assertIsString((string) $uuid->getHex());
-        $this->assertIsArray($uuid->getFieldsHex());
-        $this->assertArrayHasKey('time_low', $uuid->getFieldsHex());
-        $this->assertArrayHasKey('time_mid', $uuid->getFieldsHex());
-        $this->assertArrayHasKey('time_hi_and_version', $uuid->getFieldsHex());
-        $this->assertArrayHasKey('clock_seq_hi_and_reserved', $uuid->getFieldsHex());
-        $this->assertArrayHasKey('clock_seq_low', $uuid->getFieldsHex());
-        $this->assertArrayHasKey('node', $uuid->getFieldsHex());
-        $this->assertIsString($uuid->getTimeLowHex());
-        $this->assertIsString($uuid->getTimeMidHex());
-        $this->assertIsString($uuid->getTimeHiAndVersionHex());
-        $this->assertIsString($uuid->getClockSeqHiAndReservedHex());
-        $this->assertIsString($uuid->getClockSeqLowHex());
-        $this->assertIsString($uuid->getNodeHex());
-        $this->assertSame($uuid->getFieldsHex()['time_low'], $uuid->getTimeLowHex());
-        $this->assertSame($uuid->getFieldsHex()['time_mid'], $uuid->getTimeMidHex());
-        $this->assertSame($uuid->getFieldsHex()['time_hi_and_version'], $uuid->getTimeHiAndVersionHex());
-        $this->assertSame($uuid->getFieldsHex()['clock_seq_hi_and_reserved'], $uuid->getClockSeqHiAndReservedHex());
-        $this->assertSame($uuid->getFieldsHex()['clock_seq_low'], $uuid->getClockSeqLowHex());
-        $this->assertSame($uuid->getFieldsHex()['node'], $uuid->getNodeHex());
-        $this->assertSame(substr((string) $uuid->getHex(), 16), $uuid->getLeastSignificantBitsHex());
-        $this->assertSame(substr((string) $uuid->getHex(), 0, 16), $uuid->getMostSignificantBitsHex());
+        self::assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
+        self::assertIsInt($uuid->compareTo(Uuid::uuid1()));
+        self::assertNotSame(0, $uuid->compareTo(Uuid::uuid4()));
+        self::assertSame(0, $uuid->compareTo(clone $uuid));
+        self::assertFalse($uuid->equals(new stdClass()));
+        self::assertTrue($uuid->equals(clone $uuid));
+        self::assertIsString($uuid->getBytes());
+        self::assertInstanceOf('Ramsey\Uuid\Converter\NumberConverterInterface', $uuid->getNumberConverter());
+        self::assertIsString((string) $uuid->getHex());
+        self::assertIsArray($uuid->getFieldsHex());
+        self::assertArrayHasKey('time_low', $uuid->getFieldsHex());
+        self::assertArrayHasKey('time_mid', $uuid->getFieldsHex());
+        self::assertArrayHasKey('time_hi_and_version', $uuid->getFieldsHex());
+        self::assertArrayHasKey('clock_seq_hi_and_reserved', $uuid->getFieldsHex());
+        self::assertArrayHasKey('clock_seq_low', $uuid->getFieldsHex());
+        self::assertArrayHasKey('node', $uuid->getFieldsHex());
+        self::assertIsString($uuid->getTimeLowHex());
+        self::assertIsString($uuid->getTimeMidHex());
+        self::assertIsString($uuid->getTimeHiAndVersionHex());
+        self::assertIsString($uuid->getClockSeqHiAndReservedHex());
+        self::assertIsString($uuid->getClockSeqLowHex());
+        self::assertIsString($uuid->getNodeHex());
+        self::assertSame($uuid->getFieldsHex()['time_low'], $uuid->getTimeLowHex());
+        self::assertSame($uuid->getFieldsHex()['time_mid'], $uuid->getTimeMidHex());
+        self::assertSame($uuid->getFieldsHex()['time_hi_and_version'], $uuid->getTimeHiAndVersionHex());
+        self::assertSame($uuid->getFieldsHex()['clock_seq_hi_and_reserved'], $uuid->getClockSeqHiAndReservedHex());
+        self::assertSame($uuid->getFieldsHex()['clock_seq_low'], $uuid->getClockSeqLowHex());
+        self::assertSame($uuid->getFieldsHex()['node'], $uuid->getNodeHex());
+        self::assertSame(substr((string) $uuid->getHex(), 16), $uuid->getLeastSignificantBitsHex());
+        self::assertSame(substr((string) $uuid->getHex(), 0, 16), $uuid->getMostSignificantBitsHex());
 
-        $this->assertSame(
+        self::assertSame(
             (string) $uuid->getHex(),
             $uuid->getTimeLowHex()
             . $uuid->getTimeMidHex()
@@ -81,7 +81,7 @@ class ExpectedBehaviorTest extends TestCase
             . $uuid->getNodeHex()
         );
 
-        $this->assertSame(
+        self::assertSame(
             (string) $uuid->getHex(),
             $uuid->getFieldsHex()['time_low']
             . $uuid->getFieldsHex()['time_mid']
@@ -91,13 +91,13 @@ class ExpectedBehaviorTest extends TestCase
             . $uuid->getFieldsHex()['node']
         );
 
-        $this->assertIsString($uuid->getUrn());
-        $this->assertStringStartsWith('urn:uuid:', $uuid->getUrn());
-        $this->assertSame('urn:uuid:' . (string) $uuid->getHex(), str_replace('-', '', $uuid->getUrn()));
-        $this->assertSame((string) $uuid->getHex(), str_replace('-', '', $uuid->toString()));
-        $this->assertSame((string) $uuid->getHex(), str_replace('-', '', (string) $uuid));
+        self::assertIsString($uuid->getUrn());
+        self::assertStringStartsWith('urn:uuid:', $uuid->getUrn());
+        self::assertSame('urn:uuid:' . (string) $uuid->getHex(), str_replace('-', '', $uuid->getUrn()));
+        self::assertSame((string) $uuid->getHex(), str_replace('-', '', $uuid->toString()));
+        self::assertSame((string) $uuid->getHex(), str_replace('-', '', (string) $uuid));
 
-        $this->assertSame(
+        self::assertSame(
             $uuid->toString(),
             $uuid->getTimeLowHex() . '-'
             . $uuid->getTimeMidHex() . '-'
@@ -107,7 +107,7 @@ class ExpectedBehaviorTest extends TestCase
             . $uuid->getNodeHex()
         );
 
-        $this->assertSame(
+        self::assertSame(
             (string) $uuid,
             $uuid->getTimeLowHex() . '-'
             . $uuid->getTimeMidHex() . '-'
@@ -117,9 +117,9 @@ class ExpectedBehaviorTest extends TestCase
             . $uuid->getNodeHex()
         );
 
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame((int) substr($method, -1), $uuid->getVersion());
-        $this->assertTrue(ctype_digit((string) $uuid->getInteger()));
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame((int) substr($method, -1), $uuid->getVersion());
+        self::assertTrue(ctype_digit((string) $uuid->getInteger()));
     }
 
     public function provideStaticCreationMethods()
@@ -143,22 +143,22 @@ class ExpectedBehaviorTest extends TestCase
     {
         $uuid = Uuid::uuid1('00000fffffff', 0xffff);
 
-        $this->assertInstanceOf('DateTimeInterface', $uuid->getDateTime());
-        $this->assertSame('00000fffffff', $uuid->getNodeHex());
-        $this->assertSame('3fff', $uuid->getClockSequenceHex());
-        $this->assertSame('16383', (string) $uuid->getClockSequence());
+        self::assertInstanceOf('DateTimeInterface', $uuid->getDateTime());
+        self::assertSame('00000fffffff', $uuid->getNodeHex());
+        self::assertSame('3fff', $uuid->getClockSequenceHex());
+        self::assertSame('16383', (string) $uuid->getClockSequence());
     }
 
     public function testUuidVersion1MethodBehavior64Bit()
     {
         $uuid = Uuid::uuid1('ffffffffffff', 0xffff);
 
-        $this->assertInstanceOf('DateTimeInterface', $uuid->getDateTime());
-        $this->assertSame('ffffffffffff', $uuid->getNodeHex());
-        $this->assertSame('281474976710655', (string) $uuid->getNode());
-        $this->assertSame('3fff', $uuid->getClockSequenceHex());
-        $this->assertSame('16383', (string) $uuid->getClockSequence());
-        $this->assertTrue(ctype_digit((string) $uuid->getTimestamp()));
+        self::assertInstanceOf('DateTimeInterface', $uuid->getDateTime());
+        self::assertSame('ffffffffffff', $uuid->getNodeHex());
+        self::assertSame('281474976710655', (string) $uuid->getNode());
+        self::assertSame('3fff', $uuid->getClockSequenceHex());
+        self::assertSame('16383', (string) $uuid->getClockSequence());
+        self::assertTrue(ctype_digit((string) $uuid->getTimestamp()));
     }
 
     /**
@@ -166,8 +166,8 @@ class ExpectedBehaviorTest extends TestCase
      */
     public function testIsValid($uuid, $expected)
     {
-        $this->assertSame($expected, Uuid::isValid($uuid), "{$uuid} is not a valid UUID");
-        $this->assertSame($expected, Uuid::isValid(strtoupper($uuid)), strtoupper($uuid) . ' is not a valid UUID');
+        self::assertSame($expected, Uuid::isValid($uuid), "{$uuid} is not a valid UUID");
+        self::assertSame($expected, Uuid::isValid(strtoupper($uuid)), strtoupper($uuid) . ' is not a valid UUID');
     }
 
     public function provideIsValid()
@@ -234,9 +234,9 @@ class ExpectedBehaviorTest extends TestCase
         $serialized = serialize($uuid);
         $unserialized = unserialize($serialized);
 
-        $this->assertSame(0, $uuid->compareTo($unserialized));
-        $this->assertTrue($uuid->equals($unserialized));
-        $this->assertSame("\"{$string}\"", json_encode($uuid));
+        self::assertSame(0, $uuid->compareTo($unserialized));
+        self::assertTrue($uuid->equals($unserialized));
+        self::assertSame("\"{$string}\"", json_encode($uuid));
     }
 
     /**
@@ -260,15 +260,15 @@ class ExpectedBehaviorTest extends TestCase
 
         $uuid = Uuid::fromString($string);
 
-        $this->assertSame($components[0], (string) $uuid->getTimeLow());
-        $this->assertSame($components[1], (string) $uuid->getTimeMid());
-        $this->assertSame($components[2], (string) $uuid->getTimeHiAndVersion());
-        $this->assertSame((string) $clockSeq, (string) $uuid->getClockSequence());
-        $this->assertSame((string) $clockSeqHiAndReserved, (string) $uuid->getClockSeqHiAndReserved());
-        $this->assertSame((string) $clockSeqLow, (string) $uuid->getClockSeqLow());
-        $this->assertSame($components[4], (string) $uuid->getNode());
-        $this->assertSame($leastSignificantBits, (string) $uuid->getLeastSignificantBits());
-        $this->assertSame($mostSignificantBits, (string) $uuid->getMostSignificantBits());
+        self::assertSame($components[0], (string) $uuid->getTimeLow());
+        self::assertSame($components[1], (string) $uuid->getTimeMid());
+        self::assertSame($components[2], (string) $uuid->getTimeHiAndVersion());
+        self::assertSame((string) $clockSeq, (string) $uuid->getClockSequence());
+        self::assertSame((string) $clockSeqHiAndReserved, (string) $uuid->getClockSeqHiAndReserved());
+        self::assertSame((string) $clockSeqLow, (string) $uuid->getClockSeqLow());
+        self::assertSame($components[4], (string) $uuid->getNode());
+        self::assertSame($leastSignificantBits, (string) $uuid->getLeastSignificantBits());
+        self::assertSame($mostSignificantBits, (string) $uuid->getMostSignificantBits());
     }
 
     /**
@@ -280,20 +280,20 @@ class ExpectedBehaviorTest extends TestCase
 
         $uuid = Uuid::fromBytes($bytes);
 
-        $this->assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
-        $this->assertSame($string, $uuid->toString());
-        $this->assertSame($version, $uuid->getVersion());
-        $this->assertSame($variant, $uuid->getVariant());
+        self::assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
+        self::assertSame($string, $uuid->toString());
+        self::assertSame($version, $uuid->getVersion());
+        self::assertSame($variant, $uuid->getVariant());
 
         $components = explode('-', $string);
 
-        $this->assertSame($components[0], $uuid->getTimeLowHex());
-        $this->assertSame($components[1], $uuid->getTimeMidHex());
-        $this->assertSame($components[2], $uuid->getTimeHiAndVersionHex());
-        $this->assertSame($components[3], $uuid->getClockSeqHiAndReservedHex() . $uuid->getClockSeqLowHex());
-        $this->assertSame($components[4], $uuid->getNodeHex());
-        $this->assertSame($integer, (string) $uuid->getInteger());
-        $this->assertSame($bytes, $uuid->getBytes());
+        self::assertSame($components[0], $uuid->getTimeLowHex());
+        self::assertSame($components[1], $uuid->getTimeMidHex());
+        self::assertSame($components[2], $uuid->getTimeHiAndVersionHex());
+        self::assertSame($components[3], $uuid->getClockSeqHiAndReservedHex() . $uuid->getClockSeqLowHex());
+        self::assertSame($components[4], $uuid->getNodeHex());
+        self::assertSame($integer, (string) $uuid->getInteger());
+        self::assertSame($bytes, $uuid->getBytes());
     }
 
     /**
@@ -305,20 +305,20 @@ class ExpectedBehaviorTest extends TestCase
 
         $uuid = Uuid::fromInteger($integer);
 
-        $this->assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
-        $this->assertSame($string, $uuid->toString());
-        $this->assertSame($version, $uuid->getVersion());
-        $this->assertSame($variant, $uuid->getVariant());
+        self::assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
+        self::assertSame($string, $uuid->toString());
+        self::assertSame($version, $uuid->getVersion());
+        self::assertSame($variant, $uuid->getVariant());
 
         $components = explode('-', $string);
 
-        $this->assertSame($components[0], $uuid->getTimeLowHex());
-        $this->assertSame($components[1], $uuid->getTimeMidHex());
-        $this->assertSame($components[2], $uuid->getTimeHiAndVersionHex());
-        $this->assertSame($components[3], $uuid->getClockSeqHiAndReservedHex() . $uuid->getClockSeqLowHex());
-        $this->assertSame($components[4], $uuid->getNodeHex());
-        $this->assertSame($integer, (string) $uuid->getInteger());
-        $this->assertSame($bytes, $uuid->getBytes());
+        self::assertSame($components[0], $uuid->getTimeLowHex());
+        self::assertSame($components[1], $uuid->getTimeMidHex());
+        self::assertSame($components[2], $uuid->getTimeHiAndVersionHex());
+        self::assertSame($components[3], $uuid->getClockSeqHiAndReservedHex() . $uuid->getClockSeqLowHex());
+        self::assertSame($components[4], $uuid->getNodeHex());
+        self::assertSame($integer, (string) $uuid->getInteger());
+        self::assertSame($bytes, $uuid->getBytes());
     }
 
     /**
@@ -330,20 +330,20 @@ class ExpectedBehaviorTest extends TestCase
 
         $uuid = Uuid::fromString($string);
 
-        $this->assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
-        $this->assertSame($string, $uuid->toString());
-        $this->assertSame($version, $uuid->getVersion());
-        $this->assertSame($variant, $uuid->getVariant());
+        self::assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
+        self::assertSame($string, $uuid->toString());
+        self::assertSame($version, $uuid->getVersion());
+        self::assertSame($variant, $uuid->getVariant());
 
         $components = explode('-', $string);
 
-        $this->assertSame($components[0], $uuid->getTimeLowHex());
-        $this->assertSame($components[1], $uuid->getTimeMidHex());
-        $this->assertSame($components[2], $uuid->getTimeHiAndVersionHex());
-        $this->assertSame($components[3], $uuid->getClockSeqHiAndReservedHex() . $uuid->getClockSeqLowHex());
-        $this->assertSame($components[4], $uuid->getNodeHex());
-        $this->assertSame($integer, (string) $uuid->getInteger());
-        $this->assertSame($bytes, $uuid->getBytes());
+        self::assertSame($components[0], $uuid->getTimeLowHex());
+        self::assertSame($components[1], $uuid->getTimeMidHex());
+        self::assertSame($components[2], $uuid->getTimeHiAndVersionHex());
+        self::assertSame($components[3], $uuid->getClockSeqHiAndReservedHex() . $uuid->getClockSeqLowHex());
+        self::assertSame($components[4], $uuid->getNodeHex());
+        self::assertSame($integer, (string) $uuid->getInteger());
+        self::assertSame($bytes, $uuid->getBytes());
     }
 
     public function provideFromStringInteger()
@@ -392,12 +392,12 @@ class ExpectedBehaviorTest extends TestCase
      */
     public function testGetSetFactory()
     {
-        $this->assertInstanceOf('Ramsey\Uuid\UuidFactory', Uuid::getFactory());
+        self::assertInstanceOf('Ramsey\Uuid\UuidFactory', Uuid::getFactory());
 
         $factory = \Mockery::mock('Ramsey\Uuid\UuidFactory');
         Uuid::setFactory($factory);
 
-        $this->assertSame($factory, Uuid::getFactory());
+        self::assertSame($factory, Uuid::getFactory());
     }
 
     /**
@@ -420,13 +420,13 @@ class ExpectedBehaviorTest extends TestCase
 
         Uuid::setFactory($factory);
 
-        $this->assertSame($uuid, Uuid::uuid1('ffffffffffff', 0xffff));
-        $this->assertSame($uuid, Uuid::uuid3(Uuid::NAMESPACE_URL, 'https://example.com/foo'));
-        $this->assertSame($uuid, Uuid::uuid4());
-        $this->assertSame($uuid, Uuid::uuid5(Uuid::NAMESPACE_URL, 'https://example.com/foo'));
-        $this->assertSame($uuid, Uuid::fromBytes(hex2bin('ffffffffffffffffffffffffffffffff')));
-        $this->assertSame($uuid, Uuid::fromString('ffffffff-ffff-ffff-ffff-ffffffffffff'));
-        $this->assertSame($uuid, Uuid::fromInteger('340282366920938463463374607431768211455'));
+        self::assertSame($uuid, Uuid::uuid1('ffffffffffff', 0xffff));
+        self::assertSame($uuid, Uuid::uuid3(Uuid::NAMESPACE_URL, 'https://example.com/foo'));
+        self::assertSame($uuid, Uuid::uuid4());
+        self::assertSame($uuid, Uuid::uuid5(Uuid::NAMESPACE_URL, 'https://example.com/foo'));
+        self::assertSame($uuid, Uuid::fromBytes(hex2bin('ffffffffffffffffffffffffffffffff')));
+        self::assertSame($uuid, Uuid::fromString('ffffffff-ffff-ffff-ffff-ffffffffffff'));
+        self::assertSame($uuid, Uuid::fromInteger('340282366920938463463374607431768211455'));
     }
 
     /**
@@ -446,9 +446,9 @@ class ExpectedBehaviorTest extends TestCase
 
         $uuid = Uuid::uuid1();
 
-        $this->assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
-        $this->assertInstanceOf('Ramsey\Uuid\DegradedUuid', $uuid);
-        $this->assertInstanceOf('Ramsey\Uuid\Converter\Number\DegradedNumberConverter', $uuid->getNumberConverter());
+        self::assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
+        self::assertInstanceOf('Ramsey\Uuid\DegradedUuid', $uuid);
+        self::assertInstanceOf('Ramsey\Uuid\Converter\Number\DegradedNumberConverter', $uuid->getNumberConverter());
     }
 
     /**
@@ -473,10 +473,10 @@ class ExpectedBehaviorTest extends TestCase
 
         $uuid = Uuid::uuid4();
 
-        $this->assertSame('abcd1234', $uuid->toString());
-        $this->assertSame(hex2bin('abcd1234'), $uuid->getBytes());
-        $this->assertSame($mockUuid, Uuid::fromString('f00ba2'));
-        $this->assertSame($mockUuid, Uuid::fromBytes(hex2bin('f00ba2')));
+        self::assertSame('abcd1234', $uuid->toString());
+        self::assertSame(hex2bin('abcd1234'), $uuid->getBytes());
+        self::assertSame($mockUuid, Uuid::fromString('f00ba2'));
+        self::assertSame($mockUuid, Uuid::fromBytes(hex2bin('f00ba2')));
     }
 
     /**
@@ -496,7 +496,7 @@ class ExpectedBehaviorTest extends TestCase
 
         $uuid = Uuid::uuid4();
 
-        $this->assertSame('01234567-abcd-4432-9cba-0123456789ab', $uuid->toString());
+        self::assertSame('01234567-abcd-4432-9cba-0123456789ab', $uuid->toString());
     }
 
     /**
@@ -516,7 +516,7 @@ class ExpectedBehaviorTest extends TestCase
 
         $uuid = Uuid::uuid1();
 
-        $this->assertSame('01234567-abcd-1432-9cba-0123456789ab', $uuid->toString());
+        self::assertSame('01234567-abcd-1432-9cba-0123456789ab', $uuid->toString());
     }
 
     /**
@@ -553,7 +553,7 @@ class ExpectedBehaviorTest extends TestCase
 
         $uuid = Uuid::uuid1(null, 4095);
 
-        $this->assertSame('5e1655be-2710-1bcd-8fff-0123456789ab', $uuid->toString());
+        self::assertSame('5e1655be-2710-1bcd-8fff-0123456789ab', $uuid->toString());
     }
 
     /**
@@ -584,10 +584,10 @@ class ExpectedBehaviorTest extends TestCase
 
         Uuid::setFactory($factory);
 
-        $this->assertSame('aVersion1Uuid', \Ramsey\Uuid\v1('ffffffffffff', 0xffff));
-        $this->assertSame('aVersion3Uuid', \Ramsey\Uuid\v3(Uuid::NAMESPACE_URL, 'https://example.com/foo'));
-        $this->assertSame('aVersion4Uuid', \Ramsey\Uuid\v4());
-        $this->assertSame('aVersion5Uuid', \Ramsey\Uuid\v5(Uuid::NAMESPACE_URL, 'https://example.com/foo'));
+        self::assertSame('aVersion1Uuid', \Ramsey\Uuid\v1('ffffffffffff', 0xffff));
+        self::assertSame('aVersion3Uuid', \Ramsey\Uuid\v3(Uuid::NAMESPACE_URL, 'https://example.com/foo'));
+        self::assertSame('aVersion4Uuid', \Ramsey\Uuid\v4());
+        self::assertSame('aVersion5Uuid', \Ramsey\Uuid\v5(Uuid::NAMESPACE_URL, 'https://example.com/foo'));
     }
 
     /**
@@ -618,11 +618,11 @@ class ExpectedBehaviorTest extends TestCase
         $expectedHex = implode('', $fields);
         $expectedBytes = hex2bin($expectedHex);
 
-        $this->assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(4, $uuid->getVersion());
-        $this->assertSame($expectedBytes, $uuid->getBytes());
-        $this->assertSame($expectedHex, (string) $uuid->getHex());
+        self::assertInstanceOf('Ramsey\Uuid\UuidInterface', $uuid);
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(4, $uuid->getVersion());
+        self::assertSame($expectedBytes, $uuid->getBytes());
+        self::assertSame($expectedHex, (string) $uuid->getHex());
     }
 
     /**
@@ -630,7 +630,7 @@ class ExpectedBehaviorTest extends TestCase
      */
     public function testUuidConstants($constantName, $expected)
     {
-        $this->assertSame($expected, constant("Ramsey\\Uuid\\Uuid::{$constantName}"));
+        self::assertSame($expected, constant("Ramsey\\Uuid\\Uuid::{$constantName}"));
     }
 
     public function provideUuidConstantTests()

--- a/tests/FeatureSetTest.php
+++ b/tests/FeatureSetTest.php
@@ -21,14 +21,14 @@ class FeatureSetTest extends TestCase
     {
         $featureSet = new FeatureSet(true, true);
 
-        $this->assertInstanceOf(GuidBuilder::class, $featureSet->getBuilder());
+        self::assertInstanceOf(GuidBuilder::class, $featureSet->getBuilder());
     }
 
     public function testFallbackBuilderIsSelected(): void
     {
         $featureSet = new FeatureSet(false, true);
 
-        $this->assertInstanceOf(FallbackBuilder::class, $featureSet->getBuilder());
+        self::assertInstanceOf(FallbackBuilder::class, $featureSet->getBuilder());
     }
 
     public function testSetValidatorSetsTheProvidedValidator(): void
@@ -38,35 +38,35 @@ class FeatureSetTest extends TestCase
         $featureSet = new FeatureSet();
         $featureSet->setValidator($validator);
 
-        $this->assertSame($validator, $featureSet->getValidator());
+        self::assertSame($validator, $featureSet->getValidator());
     }
 
     public function testGetTimeConverter(): void
     {
         $featureSet = new FeatureSet();
 
-        $this->assertInstanceOf(TimeConverterInterface::class, $featureSet->getTimeConverter());
+        self::assertInstanceOf(TimeConverterInterface::class, $featureSet->getTimeConverter());
     }
 
     public function testDefaultNameGeneratorIsSelected(): void
     {
         $featureSet = new FeatureSet();
 
-        $this->assertInstanceOf(DefaultNameGenerator::class, $featureSet->getNameGenerator());
+        self::assertInstanceOf(DefaultNameGenerator::class, $featureSet->getNameGenerator());
     }
 
     public function testPeclUuidTimeGeneratorIsSelected(): void
     {
         $featureSet = new FeatureSet(false, false, false, false, true);
 
-        $this->assertInstanceOf(PeclUuidTimeGenerator::class, $featureSet->getTimeGenerator());
+        self::assertInstanceOf(PeclUuidTimeGenerator::class, $featureSet->getTimeGenerator());
     }
 
     public function testGetCalculator(): void
     {
         $featureSet = new FeatureSet();
 
-        $this->assertInstanceOf(BrickMathCalculator::class, $featureSet->getCalculator());
+        self::assertInstanceOf(BrickMathCalculator::class, $featureSet->getCalculator());
     }
 
     public function testSetNodeProvider(): void
@@ -75,6 +75,6 @@ class FeatureSetTest extends TestCase
         $featureSet = new FeatureSet();
         $featureSet->setNodeProvider($nodeProvider);
 
-        $this->assertSame($nodeProvider, $featureSet->getNodeProvider());
+        self::assertSame($nodeProvider, $featureSet->getNodeProvider());
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -22,8 +22,8 @@ class FunctionsTest extends TestCase
     {
         $v1 = v1();
 
-        $this->assertIsString($v1);
-        $this->assertSame(Uuid::UUID_TYPE_TIME, Uuid::fromString($v1)->getVersion());
+        self::assertIsString($v1);
+        self::assertSame(Uuid::UUID_TYPE_TIME, Uuid::fromString($v1)->getVersion());
     }
 
     public function testV2ReturnsVersion2UuidString(): void
@@ -38,8 +38,8 @@ class FunctionsTest extends TestCase
         /** @var FieldsInterface $fields */
         $fields = Uuid::fromString($v2)->getFields();
 
-        $this->assertIsString($v2);
-        $this->assertSame(Uuid::UUID_TYPE_DCE_SECURITY, $fields->getVersion());
+        self::assertIsString($v2);
+        self::assertSame(Uuid::UUID_TYPE_DCE_SECURITY, $fields->getVersion());
     }
 
     public function testV3ReturnsVersion3UuidString(): void
@@ -47,16 +47,16 @@ class FunctionsTest extends TestCase
         $ns = Uuid::fromString(Uuid::NAMESPACE_URL);
         $v3 = v3($ns, 'https://example.com/foo');
 
-        $this->assertIsString($v3);
-        $this->assertSame(Uuid::UUID_TYPE_HASH_MD5, Uuid::fromString($v3)->getVersion());
+        self::assertIsString($v3);
+        self::assertSame(Uuid::UUID_TYPE_HASH_MD5, Uuid::fromString($v3)->getVersion());
     }
 
     public function testV4ReturnsVersion4UuidString(): void
     {
         $v4 = v4();
 
-        $this->assertIsString($v4);
-        $this->assertSame(Uuid::UUID_TYPE_RANDOM, Uuid::fromString($v4)->getVersion());
+        self::assertIsString($v4);
+        self::assertSame(Uuid::UUID_TYPE_RANDOM, Uuid::fromString($v4)->getVersion());
     }
 
     public function testV5ReturnsVersion5UuidString(): void
@@ -64,8 +64,8 @@ class FunctionsTest extends TestCase
         $ns = Uuid::fromString(Uuid::NAMESPACE_URL);
         $v5 = v5($ns, 'https://example.com/foo');
 
-        $this->assertIsString($v5);
-        $this->assertSame(Uuid::UUID_TYPE_HASH_SHA1, Uuid::fromString($v5)->getVersion());
+        self::assertIsString($v5);
+        self::assertSame(Uuid::UUID_TYPE_HASH_SHA1, Uuid::fromString($v5)->getVersion());
     }
 
     public function testV6ReturnsVersion6UuidString(): void
@@ -78,7 +78,7 @@ class FunctionsTest extends TestCase
         /** @var FieldsInterface $fields */
         $fields = Uuid::fromString($v6)->getFields();
 
-        $this->assertIsString($v6);
-        $this->assertSame(Uuid::UUID_TYPE_PEABODY, $fields->getVersion());
+        self::assertIsString($v6);
+        self::assertSame(Uuid::UUID_TYPE_PEABODY, $fields->getVersion());
     }
 }

--- a/tests/Generator/CombGeneratorTest.php
+++ b/tests/Generator/CombGeneratorTest.php
@@ -34,7 +34,7 @@ class CombGeneratorTest extends TestCase
 
         /** @var MockObject & RandomGeneratorInterface $randomGenerator */
         $randomGenerator = $this->getMockBuilder(RandomGeneratorInterface::class)->getMock();
-        $randomGenerator->expects($this->once())
+        $randomGenerator->expects(self::once())
             ->method('generate')
             ->with($expectedLength);
 
@@ -52,9 +52,9 @@ class CombGeneratorTest extends TestCase
 
         /** @var MockObject & NumberConverterInterface $converter */
         $converter = $this->getMockBuilder(NumberConverterInterface::class)->getMock();
-        $converter->expects($this->once())
+        $converter->expects(self::once())
             ->method('toHex')
-            ->with($this->isType('string'));
+            ->with(self::isType('string'));
 
         $generator = new CombGenerator($randomGenerator, $converter);
         $generator->generate(10);
@@ -75,7 +75,7 @@ class CombGeneratorTest extends TestCase
         /** @var MockObject & NumberConverterInterface $converter */
         $converter = $this->getMockBuilder(NumberConverterInterface::class)->getMock();
         $converter->method('toHex')
-            ->with($this->isType('string'))
+            ->with(self::isType('string'))
             ->willReturn($timeHash);
 
         $time = str_pad($timeHash, 12, '0', STR_PAD_LEFT);
@@ -83,8 +83,8 @@ class CombGeneratorTest extends TestCase
 
         $generator = new CombGenerator($randomGenerator, $converter);
         $returned = $generator->generate($length);
-        $this->assertIsString($returned);
-        $this->assertSame($expected, $returned);
+        self::assertIsString($returned);
+        self::assertSame($expected, $returned);
     }
 
     /**

--- a/tests/Generator/DceSecurityGeneratorTest.php
+++ b/tests/Generator/DceSecurityGeneratorTest.php
@@ -69,10 +69,10 @@ class DceSecurityGeneratorTest extends TestCase
 
         $bytes = $dceSecurityGenerator->generate($providedDomain, $providedId, $providedNode);
 
-        $this->assertSame($expectedId, bin2hex(substr($bytes, 0, 4)));
-        $this->assertSame($expectedDomain, bin2hex(substr($bytes, 9, 1)));
-        $this->assertSame($expectedNode, bin2hex(substr($bytes, 10)));
-        $this->assertSame($expectedTimeMidHi, bin2hex(substr($bytes, 4, 4)));
+        self::assertSame($expectedId, bin2hex(substr($bytes, 0, 4)));
+        self::assertSame($expectedDomain, bin2hex(substr($bytes, 9, 1)));
+        self::assertSame($expectedNode, bin2hex(substr($bytes, 10)));
+        self::assertSame($expectedTimeMidHi, bin2hex(substr($bytes, 4, 4)));
     }
 
     /**
@@ -176,11 +176,11 @@ class DceSecurityGeneratorTest extends TestCase
 
         $hex = bin2hex($bytes);
 
-        $this->assertSame('000003e9', substr($hex, 0, 8));
-        $this->assertSame('5feb01ea', substr($hex, 8, 8));
-        $this->assertSame('00', substr($hex, 16, 2));
-        $this->assertSame('02', substr($hex, 18, 2));
-        $this->assertSame('0123456789ab', substr($hex, 20));
+        self::assertSame('000003e9', substr($hex, 0, 8));
+        self::assertSame('5feb01ea', substr($hex, 8, 8));
+        self::assertSame('00', substr($hex, 16, 2));
+        self::assertSame('02', substr($hex, 18, 2));
+        self::assertSame('0123456789ab', substr($hex, 20));
     }
 
     public function testClockSequenceUpperBounds(): void
@@ -205,11 +205,11 @@ class DceSecurityGeneratorTest extends TestCase
 
         $hex = bin2hex($bytes);
 
-        $this->assertSame('000003e9', substr($hex, 0, 8));
-        $this->assertSame('5feb01ea', substr($hex, 8, 8));
-        $this->assertSame('3f', substr($hex, 16, 2));
-        $this->assertSame('02', substr($hex, 18, 2));
-        $this->assertSame('0123456789ab', substr($hex, 20));
+        self::assertSame('000003e9', substr($hex, 0, 8));
+        self::assertSame('5feb01ea', substr($hex, 8, 8));
+        self::assertSame('3f', substr($hex, 16, 2));
+        self::assertSame('02', substr($hex, 18, 2));
+        self::assertSame('0123456789ab', substr($hex, 20));
     }
 
     public function testExceptionThrownWhenClockSequenceTooLow(): void

--- a/tests/Generator/DefaultNameGeneratorTest.php
+++ b/tests/Generator/DefaultNameGeneratorTest.php
@@ -23,7 +23,7 @@ class DefaultNameGeneratorTest extends TestCase
 
         $generator = new DefaultNameGenerator();
 
-        $this->assertSame($expectedBytes, $generator->generate($namespace, $name, $algorithm));
+        self::assertSame($expectedBytes, $generator->generate($namespace, $name, $algorithm));
     }
 
     /**

--- a/tests/Generator/DefaultTimeGeneratorTest.php
+++ b/tests/Generator/DefaultTimeGeneratorTest.php
@@ -85,10 +85,10 @@ class DefaultTimeGeneratorTest extends TestCase
 
     public function testGenerateUsesNodeProviderWhenNodeIsNull(): void
     {
-        $this->nodeProvider->expects($this->once())
+        $this->nodeProvider->expects(self::once())
             ->method('getNode')
             ->willReturn(new Hexadecimal('122f80ca9e06'));
-        $this->timeConverter->expects($this->once())
+        $this->timeConverter->expects(self::once())
             ->method('calculateTime')
             ->with($this->currentTime['sec'], $this->currentTime['usec'])
             ->willReturn($this->calculatedTime);
@@ -102,7 +102,7 @@ class DefaultTimeGeneratorTest extends TestCase
 
     public function testGenerateUsesTimeProvidersCurrentTime(): void
     {
-        $this->timeConverter->expects($this->once())
+        $this->timeConverter->expects(self::once())
             ->method('calculateTime')
             ->with($this->currentTime['sec'], $this->currentTime['usec'])
             ->willReturn($this->calculatedTime);
@@ -116,7 +116,7 @@ class DefaultTimeGeneratorTest extends TestCase
 
     public function testGenerateCalculatesTimeWithConverter(): void
     {
-        $this->timeConverter->expects($this->once())
+        $this->timeConverter->expects(self::once())
             ->method('calculateTime')
             ->with($this->currentTime['sec'], $this->currentTime['usec'])
             ->willReturn($this->calculatedTime);
@@ -150,7 +150,7 @@ class DefaultTimeGeneratorTest extends TestCase
             $this->timeProvider
         );
 
-        $this->assertSame($expectedBytes, $defaultTimeGenerator->generate($this->nodeId, $this->clockSeq));
+        self::assertSame($expectedBytes, $defaultTimeGenerator->generate($this->nodeId, $this->clockSeq));
     }
 
     /**
@@ -160,7 +160,7 @@ class DefaultTimeGeneratorTest extends TestCase
     public function testGenerateUsesRandomSequenceWhenClockSeqNull(): void
     {
         $randomInt = AspectMock::func('Ramsey\Uuid\Generator', 'random_int', 9622);
-        $this->timeConverter->expects($this->once())
+        $this->timeConverter->expects(self::once())
             ->method('calculateTime')
             ->with($this->currentTime['sec'], $this->currentTime['usec'])
             ->willReturn($this->calculatedTime);

--- a/tests/Generator/NameGeneratorFactoryTest.php
+++ b/tests/Generator/NameGeneratorFactoryTest.php
@@ -14,6 +14,6 @@ class NameGeneratorFactoryTest extends TestCase
     {
         $factory = new NameGeneratorFactory();
 
-        $this->assertInstanceOf(DefaultNameGenerator::class, $factory->getGenerator());
+        self::assertInstanceOf(DefaultNameGenerator::class, $factory->getGenerator());
     }
 }

--- a/tests/Generator/PeclUuidNameGeneratorTest.php
+++ b/tests/Generator/PeclUuidNameGeneratorTest.php
@@ -41,7 +41,7 @@ class PeclUuidNameGeneratorTest extends TestCase
         $generator = new PeclUuidNameGenerator();
         $generatedBytes = $generator->generate($namespace, $name, $algorithm);
 
-        $this->assertSame(
+        self::assertSame(
             $expectedBytes,
             $generatedBytes,
             'Expected: ' . bin2hex($expectedBytes) . '; Received: ' . bin2hex($generatedBytes)

--- a/tests/Generator/PeclUuidRandomGeneratorTest.php
+++ b/tests/Generator/PeclUuidRandomGeneratorTest.php
@@ -28,7 +28,7 @@ class PeclUuidRandomGeneratorTest extends PeclUuidTestCase
         $generator = new PeclUuidRandomGenerator();
         $uuid = $generator->generate($this->length);
 
-        $this->assertSame($this->uuidBinary, $uuid);
+        self::assertSame($this->uuidBinary, $uuid);
         $create->verifyInvoked([UUID_TYPE_RANDOM]);
         $parse->verifyInvoked([$this->uuidString]);
     }
@@ -44,7 +44,7 @@ class PeclUuidRandomGeneratorTest extends PeclUuidTestCase
         $generator = new PeclUuidRandomGenerator();
         $uuid = $generator->generate($this->length);
 
-        $this->assertSame($this->uuidBinary, $uuid);
+        self::assertSame($this->uuidBinary, $uuid);
         $create->verifyInvoked([UUID_TYPE_RANDOM]);
         $parse->verifyInvoked([$this->uuidString]);
     }

--- a/tests/Generator/PeclUuidTimeGeneratorTest.php
+++ b/tests/Generator/PeclUuidTimeGeneratorTest.php
@@ -23,7 +23,7 @@ class PeclUuidTimeGeneratorTest extends PeclUuidTestCase
         $generator = new PeclUuidTimeGenerator();
         $uuid = $generator->generate();
 
-        $this->assertSame($this->uuidBinary, $uuid);
+        self::assertSame($this->uuidBinary, $uuid);
         $create->verifyInvoked([UUID_TYPE_TIME]);
         $parse->verifyInvoked([$this->uuidString]);
     }
@@ -39,7 +39,7 @@ class PeclUuidTimeGeneratorTest extends PeclUuidTestCase
         $generator = new PeclUuidTimeGenerator();
         $uuid = $generator->generate();
 
-        $this->assertSame($this->uuidBinary, $uuid);
+        self::assertSame($this->uuidBinary, $uuid);
         $create->verifyInvoked([UUID_TYPE_TIME]);
         $parse->verifyInvoked([$this->uuidString]);
     }

--- a/tests/Generator/RandomBytesGeneratorTest.php
+++ b/tests/Generator/RandomBytesGeneratorTest.php
@@ -39,7 +39,7 @@ class RandomBytesGeneratorTest extends TestCase
         $openSsl = AspectMock::func('Ramsey\Uuid\Generator', 'random_bytes', $bytes);
         $generator = new RandomBytesGenerator();
 
-        $this->assertSame($bytes, $generator->generate($length));
+        self::assertSame($bytes, $generator->generate($length));
         $openSsl->verifyInvokedOnce([$length]);
     }
 
@@ -55,7 +55,7 @@ class RandomBytesGeneratorTest extends TestCase
         $bytes = hex2bin($hex);
         AspectMock::func('Ramsey\Uuid\Generator', 'random_bytes', $bytes);
         $generator = new RandomBytesGenerator();
-        $this->assertSame($bytes, $generator->generate($length));
+        self::assertSame($bytes, $generator->generate($length));
     }
 
     /**

--- a/tests/Generator/RandomGeneratorFactoryTest.php
+++ b/tests/Generator/RandomGeneratorFactoryTest.php
@@ -14,6 +14,6 @@ class RandomGeneratorFactoryTest extends TestCase
     {
         $generator = (new RandomGeneratorFactory())->getGenerator();
 
-        $this->assertInstanceOf(RandomBytesGenerator::class, $generator);
+        self::assertInstanceOf(RandomBytesGenerator::class, $generator);
     }
 }

--- a/tests/Generator/RandomLibAdapterTest.php
+++ b/tests/Generator/RandomLibAdapterTest.php
@@ -25,7 +25,7 @@ class RandomLibAdapterTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->assertInstanceOf(RandomLibAdapter::class, new RandomLibAdapter($generator));
+        self::assertInstanceOf(RandomLibAdapter::class, new RandomLibAdapter($generator));
     }
 
     /**
@@ -37,7 +37,7 @@ class RandomLibAdapterTest extends TestCase
         $factory = Mockery::mock('overload:' . RandomLibFactory::class);
         $factory->shouldReceive('getHighStrengthGenerator')->once();
 
-        $this->assertInstanceOf(RandomLibAdapter::class, new RandomLibAdapter());
+        self::assertInstanceOf(RandomLibAdapter::class, new RandomLibAdapter());
     }
 
     public function testGenerateUsesGenerator(): void
@@ -46,7 +46,7 @@ class RandomLibAdapterTest extends TestCase
         $generator = $this->getMockBuilder(Generator::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $generator->expects($this->once())
+        $generator->expects(self::once())
             ->method('generate')
             ->with($length)
             ->willReturn('foo');
@@ -60,12 +60,12 @@ class RandomLibAdapterTest extends TestCase
         $generator = $this->getMockBuilder(Generator::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $generator->expects($this->once())
+        $generator->expects(self::once())
             ->method('generate')
             ->willReturn('random-string');
 
         $adapter = new RandomLibAdapter($generator);
         $result = $adapter->generate(1);
-        $this->assertSame('random-string', $result);
+        self::assertSame('random-string', $result);
     }
 }

--- a/tests/Generator/TimeGeneratorFactoryTest.php
+++ b/tests/Generator/TimeGeneratorFactoryTest.php
@@ -28,6 +28,6 @@ class TimeGeneratorFactoryTest extends TestCase
         $factory = new TimeGeneratorFactory($nodeProvider, $timeConverter, $timeProvider);
         $generator = $factory->getGenerator();
 
-        $this->assertInstanceOf(TimeGeneratorInterface::class, $generator);
+        self::assertInstanceOf(TimeGeneratorInterface::class, $generator);
     }
 }

--- a/tests/Guid/FieldsTest.php
+++ b/tests/Guid/FieldsTest.php
@@ -109,9 +109,9 @@ class FieldsTest extends TestCase
         $result = $fields->$methodName();
 
         if ($result instanceof Hexadecimal) {
-            $this->assertSame($expectedValue, $result->toString());
+            self::assertSame($expectedValue, $result->toString());
         } else {
-            $this->assertSame($expectedValue, $result);
+            self::assertSame($expectedValue, $result);
         }
     }
 
@@ -199,6 +199,6 @@ class FieldsTest extends TestCase
         $serializedFields = serialize($fields);
         $unserializedFields = unserialize($serializedFields);
 
-        $this->assertSame($fields->getBytes(), $unserializedFields->getBytes());
+        self::assertSame($fields->getBytes(), $unserializedFields->getBytes());
     }
 }

--- a/tests/Math/BrickMathCalculatorTest.php
+++ b/tests/Math/BrickMathCalculatorTest.php
@@ -23,7 +23,7 @@ class BrickMathCalculatorTest extends TestCase
 
         $result = $calculator->add($int1, $int2, $int3);
 
-        $this->assertSame('18', $result->toString());
+        self::assertSame('18', $result->toString());
     }
 
     public function testSubtract(): void
@@ -36,7 +36,7 @@ class BrickMathCalculatorTest extends TestCase
 
         $result = $calculator->subtract($int1, $int2, $int3);
 
-        $this->assertSame('-8', $result->toString());
+        self::assertSame('-8', $result->toString());
     }
 
     public function testMultiply(): void
@@ -49,7 +49,7 @@ class BrickMathCalculatorTest extends TestCase
 
         $result = $calculator->multiply($int1, $int2, $int3);
 
-        $this->assertSame('210', $result->toString());
+        self::assertSame('210', $result->toString());
     }
 
     public function testDivide(): void
@@ -62,7 +62,7 @@ class BrickMathCalculatorTest extends TestCase
 
         $result = $calculator->divide(RoundingMode::HALF_UP, 0, $int1, $int2, $int3);
 
-        $this->assertSame('24', $result->toString());
+        self::assertSame('24', $result->toString());
     }
 
     public function testFromBase(): void
@@ -71,8 +71,8 @@ class BrickMathCalculatorTest extends TestCase
 
         $result = $calculator->fromBase('ffffffffffffffffffff', 16);
 
-        $this->assertInstanceOf(IntegerObject::class, $result);
-        $this->assertSame('1208925819614629174706175', $result->toString());
+        self::assertInstanceOf(IntegerObject::class, $result);
+        self::assertSame('1208925819614629174706175', $result->toString());
     }
 
     public function testToBase(): void
@@ -80,7 +80,7 @@ class BrickMathCalculatorTest extends TestCase
         $intValue = new IntegerObject('1208925819614629174706175');
         $calculator = new BrickMathCalculator();
 
-        $this->assertSame('ffffffffffffffffffff', $calculator->toBase($intValue, 16));
+        self::assertSame('ffffffffffffffffffff', $calculator->toBase($intValue, 16));
     }
 
     public function testToHexadecimal(): void
@@ -90,8 +90,8 @@ class BrickMathCalculatorTest extends TestCase
 
         $result = $calculator->toHexadecimal($intValue);
 
-        $this->assertInstanceOf(Hexadecimal::class, $result);
-        $this->assertSame('ffffffffffffffffffff', $result->toString());
+        self::assertInstanceOf(Hexadecimal::class, $result);
+        self::assertSame('ffffffffffffffffffff', $result->toString());
     }
 
     public function testFromBaseThrowsException(): void

--- a/tests/Nonstandard/FieldsTest.php
+++ b/tests/Nonstandard/FieldsTest.php
@@ -41,9 +41,9 @@ class FieldsTest extends TestCase
         $result = $fields->$methodName();
 
         if ($result instanceof Hexadecimal) {
-            $this->assertSame($expectedValue, $result->toString());
+            self::assertSame($expectedValue, $result->toString());
         } else {
-            $this->assertSame($expectedValue, $result);
+            self::assertSame($expectedValue, $result);
         }
     }
 
@@ -75,6 +75,6 @@ class FieldsTest extends TestCase
         $serializedFields = serialize($fields);
         $unserializedFields = unserialize($serializedFields);
 
-        $this->assertSame($fields->getBytes(), $unserializedFields->getBytes());
+        self::assertSame($fields->getBytes(), $unserializedFields->getBytes());
     }
 }

--- a/tests/Nonstandard/UuidV6Test.php
+++ b/tests/Nonstandard/UuidV6Test.php
@@ -71,8 +71,8 @@ class UuidV6Test extends TestCase
 
         $date = $object->getDateTime();
 
-        $this->assertInstanceOf(DateTimeImmutable::class, $date);
-        $this->assertSame($expected, $date->format('U.u'));
+        self::assertInstanceOf(DateTimeImmutable::class, $date);
+        self::assertSame($expected, $date->format('U.u'));
     }
 
     /**
@@ -109,10 +109,10 @@ class UuidV6Test extends TestCase
         $uuid6 = Uuid::fromString($uuidv6);
         $uuid1 = $uuid6->toUuidV1();
 
-        $this->assertSame($uuidv6, $uuid6->toString());
-        $this->assertSame($uuidv1, $uuid1->toString());
+        self::assertSame($uuidv6, $uuid6->toString());
+        self::assertSame($uuidv1, $uuid1->toString());
 
-        $this->assertSame(
+        self::assertSame(
             $uuid6->getDateTime()->format('U.u'),
             $uuid1->getDateTime()->format('U.u')
         );
@@ -128,10 +128,10 @@ class UuidV6Test extends TestCase
         $uuid1 = $uuid->toUuidV1();
         $uuid6 = UuidV6::fromUuidV1($uuid1);
 
-        $this->assertSame($uuidv1, $uuid1->toString());
-        $this->assertSame($uuidv6, $uuid6->toString());
+        self::assertSame($uuidv1, $uuid1->toString());
+        self::assertSame($uuidv6, $uuid6->toString());
 
-        $this->assertSame(
+        self::assertSame(
             $uuid1->getDateTime()->format('U.u'),
             $uuid6->getDateTime()->format('U.u')
         );

--- a/tests/Provider/Dce/SystemDceSecurityProviderTest.php
+++ b/tests/Provider/Dce/SystemDceSecurityProviderTest.php
@@ -38,7 +38,7 @@ class SystemDceSecurityProviderTest extends TestCase
             } catch (DceSecurityException $e) {
                 $caughtException++;
 
-                $this->assertSame(
+                self::assertSame(
                     'Unable to get a user identifier using the system DCE '
                     . 'Security provider; please provide a custom identifier or '
                     . 'use a different provider',
@@ -47,7 +47,7 @@ class SystemDceSecurityProviderTest extends TestCase
             }
         }
 
-        $this->assertSame(5, $caughtException);
+        self::assertSame(5, $caughtException);
     }
 
     /**
@@ -147,9 +147,9 @@ class SystemDceSecurityProviderTest extends TestCase
 
         $uid = $provider->getUid();
 
-        $this->assertInstanceOf(IntegerObject::class, $uid);
-        $this->assertSame($expectedId, $uid->toString());
-        $this->assertSame($uid, $provider->getUid());
+        self::assertInstanceOf(IntegerObject::class, $uid);
+        self::assertSame($expectedId, $uid->toString());
+        self::assertSame($uid, $provider->getUid());
     }
 
     /**
@@ -199,9 +199,9 @@ class SystemDceSecurityProviderTest extends TestCase
 
         $uid = $provider->getUid();
 
-        $this->assertInstanceOf(IntegerObject::class, $uid);
-        $this->assertSame($id, $uid->toString());
-        $this->assertSame($uid, $provider->getUid());
+        self::assertInstanceOf(IntegerObject::class, $uid);
+        self::assertSame($id, $uid->toString());
+        self::assertSame($uid, $provider->getUid());
     }
 
     /**
@@ -227,7 +227,7 @@ class SystemDceSecurityProviderTest extends TestCase
             } catch (DceSecurityException $e) {
                 $caughtException++;
 
-                $this->assertSame(
+                self::assertSame(
                     'Unable to get a group identifier using the system DCE '
                     . 'Security provider; please provide a custom identifier or '
                     . 'use a different provider',
@@ -236,7 +236,7 @@ class SystemDceSecurityProviderTest extends TestCase
             }
         }
 
-        $this->assertSame(5, $caughtException);
+        self::assertSame(5, $caughtException);
     }
 
     /**
@@ -298,9 +298,9 @@ class SystemDceSecurityProviderTest extends TestCase
 
         $gid = $provider->getGid();
 
-        $this->assertInstanceOf(IntegerObject::class, $gid);
-        $this->assertSame($id, $gid->toString());
-        $this->assertSame($gid, $provider->getGid());
+        self::assertInstanceOf(IntegerObject::class, $gid);
+        self::assertSame($id, $gid->toString());
+        self::assertSame($gid, $provider->getGid());
     }
 
     /**
@@ -419,9 +419,9 @@ class SystemDceSecurityProviderTest extends TestCase
 
         $gid = $provider->getGid();
 
-        $this->assertInstanceOf(IntegerObject::class, $gid);
-        $this->assertSame($expectedId, $gid->toString());
-        $this->assertSame($gid, $provider->getGid());
+        self::assertInstanceOf(IntegerObject::class, $gid);
+        self::assertSame($expectedId, $gid->toString());
+        self::assertSame($gid, $provider->getGid());
     }
 
     /**

--- a/tests/Provider/Node/FallbackNodeProviderTest.php
+++ b/tests/Provider/Node/FallbackNodeProviderTest.php
@@ -19,11 +19,11 @@ class FallbackNodeProviderTest extends TestCase
     public function testGetNodeCallsGetNodeOnEachProviderUntilNodeFound(): void
     {
         $providerWithNode = $this->getMockBuilder(NodeProviderInterface::class)->getMock();
-        $providerWithNode->expects($this->once())
+        $providerWithNode->expects(self::once())
             ->method('getNode')
             ->willReturn(new Hexadecimal('57764a07f756'));
         $providerWithoutNode = $this->getMockBuilder(NodeProviderInterface::class)->getMock();
-        $providerWithoutNode->expects($this->once())
+        $providerWithoutNode->expects(self::once())
             ->method('getNode')
             ->willThrowException(new NodeException());
 
@@ -34,15 +34,15 @@ class FallbackNodeProviderTest extends TestCase
     public function testGetNodeReturnsNodeFromFirstProviderWithNode(): void
     {
         $providerWithoutNode = $this->getMockBuilder(NodeProviderInterface::class)->getMock();
-        $providerWithoutNode->expects($this->once())
+        $providerWithoutNode->expects(self::once())
             ->method('getNode')
             ->willThrowException(new NodeException());
         $providerWithNode = $this->getMockBuilder(NodeProviderInterface::class)->getMock();
-        $providerWithNode->expects($this->once())
+        $providerWithNode->expects(self::once())
             ->method('getNode')
             ->willReturn(new Hexadecimal('57764a07f756'));
         $anotherProviderWithoutNode = $this->getMockBuilder(NodeProviderInterface::class)->getMock();
-        $anotherProviderWithoutNode->expects($this->never())
+        $anotherProviderWithoutNode->expects(self::never())
             ->method('getNode');
 
         $provider = new FallbackNodeProvider(new NodeProviderCollection(
@@ -50,7 +50,7 @@ class FallbackNodeProviderTest extends TestCase
         ));
         $node = $provider->getNode();
 
-        $this->assertSame('57764a07f756', $node->toString());
+        self::assertSame('57764a07f756', $node->toString());
     }
 
     public function testGetNodeThrowsExceptionWhenNoNodesFound(): void
@@ -88,11 +88,11 @@ class FallbackNodeProviderTest extends TestCase
         /** @var NodeProviderCollection $unserializedNodeProviderCollection */
         $unserializedNodeProviderCollection = unserialize($serializedNodeProviderCollection);
 
-        $this->assertInstanceOf(NodeProviderCollection::class, $unserializedNodeProviderCollection);
+        self::assertInstanceOf(NodeProviderCollection::class, $unserializedNodeProviderCollection);
 
         foreach ($unserializedNodeProviderCollection as $nodeProvider) {
-            $this->assertInstanceOf(NodeProviderInterface::class, $nodeProvider);
-            $this->assertInstanceOf(Hexadecimal::class, $nodeProvider->getNode());
+            self::assertInstanceOf(NodeProviderInterface::class, $nodeProvider);
+            self::assertInstanceOf(Hexadecimal::class, $nodeProvider->getNode());
         }
     }
 }

--- a/tests/Provider/Node/RandomNodeProviderTest.php
+++ b/tests/Provider/Node/RandomNodeProviderTest.php
@@ -37,7 +37,7 @@ class RandomNodeProviderTest extends TestCase
         $provider = new RandomNodeProvider();
         $node = $provider->getNode();
 
-        $this->assertSame($expectedNode, $node->toString());
+        self::assertSame($expectedNode, $node->toString());
         $randomBytes->verifyInvoked([6]);
     }
 
@@ -55,7 +55,7 @@ class RandomNodeProviderTest extends TestCase
         $randomBytes = AspectMock::func('Ramsey\Uuid\Provider\Node', 'random_bytes', $bytes);
         $provider = new RandomNodeProvider();
 
-        $this->assertSame($expectedNode, $provider->getNode()->toString());
+        self::assertSame($expectedNode, $provider->getNode()->toString());
         $randomBytes->verifyInvoked([6]);
     }
 
@@ -74,7 +74,7 @@ class RandomNodeProviderTest extends TestCase
         $randomBytes = AspectMock::func('Ramsey\Uuid\Provider\Node', 'random_bytes', $bytes);
         $provider = new RandomNodeProvider();
 
-        $this->assertSame($expectedNode, $provider->getNode()->toString());
+        self::assertSame($expectedNode, $provider->getNode()->toString());
         $randomBytes->verifyInvoked([6]);
     }
 
@@ -90,7 +90,7 @@ class RandomNodeProviderTest extends TestCase
         $randomBytes = AspectMock::func('Ramsey\Uuid\Provider\Node', 'random_bytes', $bytes);
         $provider = new RandomNodeProvider();
 
-        $this->assertSame($expectedNode, $provider->getNode()->toString());
+        self::assertSame($expectedNode, $provider->getNode()->toString());
         $randomBytes->verifyInvoked([6]);
     }
 
@@ -116,7 +116,7 @@ class RandomNodeProviderTest extends TestCase
         // Recombine the node bytes.
         $node = $nodeMsb . $nodeLsb;
 
-        $this->assertSame('010000000000', $node);
+        self::assertSame('010000000000', $node);
     }
 
     /**

--- a/tests/Provider/Node/StaticNodeProviderTest.php
+++ b/tests/Provider/Node/StaticNodeProviderTest.php
@@ -18,7 +18,7 @@ class StaticNodeProviderTest extends TestCase
     {
         $staticNode = new StaticNodeProvider($node);
 
-        $this->assertSame($expectedNode, $staticNode->getNode()->toString());
+        self::assertSame($expectedNode, $staticNode->getNode()->toString());
     }
 
     /**

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -82,15 +82,15 @@ class SystemNodeProviderTest extends TestCase
         $node = $provider->getNode();
 
         /* Assert the result match expectations */
-        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
+        self::assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
 
-        $this->assertSame($expected, $node->toString());
+        self::assertSame($expected, $node->toString());
 
         $message = vsprintf(
             'Node should be a hexadecimal string of 12 characters. Actual node: %s (length: %s)',
             [$node->toString(), strlen($node->toString()),]
         );
-        $this->assertRegExp('/^[A-Fa-f0-9]{12}$/', $node->toString(), $message);
+        self::assertRegExp('/^[A-Fa-f0-9]{12}$/', $node->toString(), $message);
     }
 
     /**
@@ -122,8 +122,8 @@ class SystemNodeProviderTest extends TestCase
         }
 
         /* Assert */
-        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
-        $this->assertInstanceOf(NodeException::class, $exception);
+        self::assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
+        self::assertInstanceOf(NodeException::class, $exception);
     }
 
     /**
@@ -149,9 +149,9 @@ class SystemNodeProviderTest extends TestCase
         $node = $provider->getNode();
 
         /* Assert */
-        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
+        self::assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
 
-        $this->assertSame($expected, $node->toString());
+        self::assertSame($expected, $node->toString());
     }
 
     /**
@@ -183,8 +183,8 @@ class SystemNodeProviderTest extends TestCase
         }
 
         /* Assert */
-        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
-        $this->assertInstanceOf(NodeException::class, $exception);
+        self::assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
+        self::assertInstanceOf(NodeException::class, $exception);
     }
 
     /**
@@ -209,9 +209,9 @@ class SystemNodeProviderTest extends TestCase
         $node = $provider->getNode();
 
         /* Assert */
-        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
+        self::assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
 
-        $this->assertSame('aabbccddeeff', $node->toString());
+        self::assertSame('aabbccddeeff', $node->toString());
     }
 
     /**
@@ -242,8 +242,8 @@ class SystemNodeProviderTest extends TestCase
         }
 
         /* Assert */
-        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
-        $this->assertInstanceOf(NodeException::class, $exception);
+        self::assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
+        self::assertInstanceOf(NodeException::class, $exception);
     }
 
     /**
@@ -281,9 +281,9 @@ class SystemNodeProviderTest extends TestCase
         }
 
         /* Assert */
-        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
-        $this->assertInstanceOf(NodeException::class, $exception1);
-        $this->assertInstanceOf(NodeException::class, $exception2);
+        self::assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
+        self::assertInstanceOf(NodeException::class, $exception1);
+        self::assertInstanceOf(NodeException::class, $exception2);
     }
 
     /**
@@ -322,7 +322,7 @@ class SystemNodeProviderTest extends TestCase
             $fileGetContentsAssert = ['mock address path'];
             $isReadableAssert = $fileGetContentsAssert;
         }
-        $this->assertMockFunctions(
+        self::assertMockFunctions(
             $fileGetContentsAssert,
             $globBodyAssert,
             [$command],
@@ -331,7 +331,7 @@ class SystemNodeProviderTest extends TestCase
             $isReadableAssert
         );
 
-        $this->assertInstanceOf(NodeException::class, $exception);
+        self::assertInstanceOf(NodeException::class, $exception);
     }
 
     /**
@@ -357,9 +357,9 @@ class SystemNodeProviderTest extends TestCase
         $node2 = $provider->getNode();
 
         /* Assert */
-        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
+        self::assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
 
-        $this->assertSame($node->toString(), $node2->toString());
+        self::assertSame($node->toString(), $node2->toString());
     }
 
     /**
@@ -385,9 +385,9 @@ class SystemNodeProviderTest extends TestCase
         $node2 = $provider->getNode();
 
         /* Assert */
-        $this->assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
+        self::assertMockFunctions(null, null, ['netstat -ie 2>&1'], ['PHP_OS'], ['disable_functions']);
 
-        $this->assertSame($node->toString(), $node2->toString());
+        self::assertSame($node->toString(), $node2->toString());
     }
 
     /**
@@ -433,7 +433,7 @@ class SystemNodeProviderTest extends TestCase
             $iniGetDisableFunctionsAssert = null;
             $isReadableAssert = $fileGetContentsAssert;
         }
-        $this->assertMockFunctions(
+        self::assertMockFunctions(
             $fileGetContentsAssert,
             $globBodyAssert,
             $passthruBodyAssert,
@@ -442,7 +442,7 @@ class SystemNodeProviderTest extends TestCase
             $isReadableAssert
         );
 
-        $this->assertSame('010203040506', $node->toString());
+        self::assertSame('010203040506', $node->toString());
     }
 
     /**
@@ -467,7 +467,7 @@ class SystemNodeProviderTest extends TestCase
         $node = $provider->getNode();
 
         /* Assert */
-        $this->assertMockFunctions(
+        self::assertMockFunctions(
             null,
             ['/sys/class/net/*/address'],
             ['netstat -ie 2>&1'],
@@ -475,7 +475,7 @@ class SystemNodeProviderTest extends TestCase
             ['disable_functions']
         );
 
-        $this->assertSame('010203040506', $node->toString());
+        self::assertSame('010203040506', $node->toString());
     }
 
     /**
@@ -500,7 +500,7 @@ class SystemNodeProviderTest extends TestCase
         $node = $provider->getNode();
 
         /* Assert */
-        $this->assertMockFunctions(
+        self::assertMockFunctions(
             null,
             ['/sys/class/net/*/address'],
             ['netstat -ie 2>&1'],
@@ -508,7 +508,7 @@ class SystemNodeProviderTest extends TestCase
             ['disable_functions']
         );
 
-        $this->assertSame('010203040506', $node->toString());
+        self::assertSame('010203040506', $node->toString());
     }
 
     /**
@@ -534,7 +534,7 @@ class SystemNodeProviderTest extends TestCase
         $node = $provider->getNode();
 
         /* Assert */
-        $this->assertMockFunctions(
+        self::assertMockFunctions(
             null,
             ['/sys/class/net/*/address'],
             ['netstat -ie 2>&1'],
@@ -543,7 +543,7 @@ class SystemNodeProviderTest extends TestCase
             ['mock address path 1', 'mock address path 2']
         );
 
-        $this->assertSame('010203040506', $node->toString());
+        self::assertSame('010203040506', $node->toString());
     }
 
     /**
@@ -572,7 +572,7 @@ class SystemNodeProviderTest extends TestCase
         }
 
         /* Assert */
-        $this->assertMockFunctions(
+        self::assertMockFunctions(
             null,
             null,
             null,
@@ -580,7 +580,7 @@ class SystemNodeProviderTest extends TestCase
             ['disable_functions']
         );
 
-        $this->assertInstanceOf(NodeException::class, $exception);
+        self::assertInstanceOf(NodeException::class, $exception);
     }
 
     /**

--- a/tests/Provider/Time/FixedTimeProviderTest.php
+++ b/tests/Provider/Time/FixedTimeProviderTest.php
@@ -15,7 +15,7 @@ class FixedTimeProviderTest extends TestCase
         $time = new Time(1458844556, 200997);
         $provider = new FixedTimeProvider($time);
 
-        $this->assertSame($time, $provider->getTime());
+        self::assertSame($time, $provider->getTime());
     }
 
     public function testGetTimeReturnsTimeAfterChange(): void
@@ -23,19 +23,19 @@ class FixedTimeProviderTest extends TestCase
         $time = new Time(1458844556, 200997);
         $provider = new FixedTimeProvider($time);
 
-        $this->assertSame('1458844556', $provider->getTime()->getSeconds()->toString());
-        $this->assertSame('200997', $provider->getTime()->getMicroseconds()->toString());
+        self::assertSame('1458844556', $provider->getTime()->getSeconds()->toString());
+        self::assertSame('200997', $provider->getTime()->getMicroseconds()->toString());
 
         $provider->setSec(1050804050);
 
-        $this->assertSame('1050804050', $provider->getTime()->getSeconds()->toString());
-        $this->assertSame('200997', $provider->getTime()->getMicroseconds()->toString());
+        self::assertSame('1050804050', $provider->getTime()->getSeconds()->toString());
+        self::assertSame('200997', $provider->getTime()->getMicroseconds()->toString());
 
         $provider->setUsec(30192);
 
-        $this->assertSame('1050804050', $provider->getTime()->getSeconds()->toString());
-        $this->assertSame('30192', $provider->getTime()->getMicroseconds()->toString());
+        self::assertSame('1050804050', $provider->getTime()->getSeconds()->toString());
+        self::assertSame('30192', $provider->getTime()->getMicroseconds()->toString());
 
-        $this->assertNotSame($time, $provider->getTime());
+        self::assertNotSame($time, $provider->getTime());
     }
 }

--- a/tests/Provider/Time/SystemTimeProviderTest.php
+++ b/tests/Provider/Time/SystemTimeProviderTest.php
@@ -15,6 +15,6 @@ class SystemTimeProviderTest extends TestCase
         $provider = new SystemTimeProvider();
         $time = $provider->getTime();
 
-        $this->assertInstanceOf(Time::class, $time);
+        self::assertInstanceOf(Time::class, $time);
     }
 }

--- a/tests/Rfc4122/FieldsTest.php
+++ b/tests/Rfc4122/FieldsTest.php
@@ -104,9 +104,9 @@ class FieldsTest extends TestCase
         $result = $fields->$methodName();
 
         if ($result instanceof Hexadecimal) {
-            $this->assertSame($expectedValue, $result->toString());
+            self::assertSame($expectedValue, $result->toString());
         } else {
-            $this->assertSame($expectedValue, $result);
+            self::assertSame($expectedValue, $result);
         }
     }
 
@@ -210,7 +210,7 @@ class FieldsTest extends TestCase
         $serializedFields = serialize($fields);
         $unserializedFields = unserialize($serializedFields);
 
-        $this->assertSame($fields->getBytes(), $unserializedFields->getBytes());
+        self::assertSame($fields->getBytes(), $unserializedFields->getBytes());
     }
 
     public function testSerializingFieldsWithOldFormat(): void
@@ -220,6 +220,6 @@ class FieldsTest extends TestCase
         $serializedFields = 'C:26:"Ramsey\Uuid\Rfc4122\Fields":24:{s81YauPKRPOYjPTWZsG/TQ==}';
         $unserializedFields = unserialize($serializedFields);
 
-        $this->assertSame($fields->getBytes(), $unserializedFields->getBytes());
+        self::assertSame($fields->getBytes(), $unserializedFields->getBytes());
     }
 }

--- a/tests/Rfc4122/UuidBuilderTest.php
+++ b/tests/Rfc4122/UuidBuilderTest.php
@@ -46,8 +46,8 @@ class UuidBuilderTest extends TestCase
         /** @var Fields $fields */
         $fields = $result->getFields();
 
-        $this->assertInstanceOf($expectedClass, $result);
-        $this->assertSame($expectedVersion, $fields->getVersion());
+        self::assertInstanceOf($expectedClass, $result);
+        self::assertSame($expectedVersion, $fields->getVersion());
     }
 
     /**

--- a/tests/Rfc4122/UuidV1Test.php
+++ b/tests/Rfc4122/UuidV1Test.php
@@ -70,8 +70,8 @@ class UuidV1Test extends TestCase
 
         $date = $object->getDateTime();
 
-        $this->assertInstanceOf(DateTimeImmutable::class, $date);
-        $this->assertSame($expected, $date->format('U.u'));
+        self::assertInstanceOf(DateTimeImmutable::class, $date);
+        self::assertSame($expected, $date->format('U.u'));
     }
 
     /**

--- a/tests/Rfc4122/UuidV2Test.php
+++ b/tests/Rfc4122/UuidV2Test.php
@@ -101,14 +101,14 @@ class UuidV2Test extends TestCase
         /** @var FieldsInterface $fields */
         $fields = $uuid->getFields();
 
-        $this->assertSame($expectedDomain, $uuid->getLocalDomain());
-        $this->assertSame($expectedDomainName, $uuid->getLocalDomainName());
-        $this->assertInstanceOf(Integer::class, $uuid->getLocalIdentifier());
-        $this->assertSame($expectedIdentifier, $uuid->getLocalIdentifier()->toString());
-        $this->assertSame($expectedTimestamp, $fields->getTimestamp()->toString());
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame($expectedTime, $uuid->getDateTime()->format('U.u'));
-        $this->assertSame('1334567890ab', $fields->getNode()->toString());
+        self::assertSame($expectedDomain, $uuid->getLocalDomain());
+        self::assertSame($expectedDomainName, $uuid->getLocalDomainName());
+        self::assertInstanceOf(Integer::class, $uuid->getLocalIdentifier());
+        self::assertSame($expectedIdentifier, $uuid->getLocalIdentifier()->toString());
+        self::assertSame($expectedTimestamp, $fields->getTimestamp()->toString());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame($expectedTime, $uuid->getDateTime()->format('U.u'));
+        self::assertSame('1334567890ab', $fields->getNode()->toString());
     }
 
     /**

--- a/tests/Rfc4122/ValidatorTest.php
+++ b/tests/Rfc4122/ValidatorTest.php
@@ -30,7 +30,7 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
 
         foreach ($variations as $variation) {
-            $this->assertSame($expected, $validator->validate($variation));
+            self::assertSame($expected, $validator->validate($variation));
         }
     }
 
@@ -97,6 +97,6 @@ class ValidatorTest extends TestCase
 
         $validator = new Validator();
 
-        $this->assertSame($expectedPattern, $validator->getPattern());
+        self::assertSame($expectedPattern, $validator->getPattern());
     }
 }

--- a/tests/Rfc4122/VariantTraitTest.php
+++ b/tests/Rfc4122/VariantTraitTest.php
@@ -54,7 +54,7 @@ class VariantTraitTest extends TestCase
             'getBytes' => $bytes,
         ]);
 
-        $this->assertSame($expectedVariant, $trait->getVariant());
+        self::assertSame($expectedVariant, $trait->getVariant());
     }
 
     /**

--- a/tests/Type/DecimalTest.php
+++ b/tests/Type/DecimalTest.php
@@ -24,9 +24,9 @@ class DecimalTest extends TestCase
     {
         $decimal = new Decimal($value);
 
-        $this->assertSame($expected, $decimal->toString());
-        $this->assertSame($expected, (string) $decimal);
-        $this->assertSame($expectedIsNegative, $decimal->isNegative());
+        self::assertSame($expected, $decimal->toString());
+        self::assertSame($expected, (string) $decimal);
+        self::assertSame($expectedIsNegative, $decimal->isNegative());
     }
 
     /**
@@ -285,7 +285,7 @@ class DecimalTest extends TestCase
         $serializedDecimal = serialize($decimal);
         $unserializedDecimal = unserialize($serializedDecimal);
 
-        $this->assertSame($expected, $unserializedDecimal->toString());
+        self::assertSame($expected, $unserializedDecimal->toString());
     }
 
     /**
@@ -298,6 +298,6 @@ class DecimalTest extends TestCase
         $decimal = new Decimal($value);
         $expectedJson = sprintf('"%s"', $expected);
 
-        $this->assertSame($expectedJson, json_encode($decimal));
+        self::assertSame($expectedJson, json_encode($decimal));
     }
 }

--- a/tests/Type/HexadecimalTest.php
+++ b/tests/Type/HexadecimalTest.php
@@ -22,8 +22,8 @@ class HexadecimalTest extends TestCase
     {
         $hexadecimal = new Hexadecimal($value);
 
-        $this->assertSame($expected, $hexadecimal->toString());
-        $this->assertSame($expected, (string) $hexadecimal);
+        self::assertSame($expected, $hexadecimal->toString());
+        self::assertSame($expected, (string) $hexadecimal);
     }
 
     /**
@@ -84,7 +84,7 @@ class HexadecimalTest extends TestCase
         $serializedHexadecimal = serialize($hexadecimal);
         $unserializedHexadecimal = unserialize($serializedHexadecimal);
 
-        $this->assertSame($expected, $unserializedHexadecimal->toString());
+        self::assertSame($expected, $unserializedHexadecimal->toString());
     }
 
     /**
@@ -97,6 +97,6 @@ class HexadecimalTest extends TestCase
         $hexadecimal = new Hexadecimal($value);
         $expectedJson = sprintf('"%s"', $expected);
 
-        $this->assertSame($expectedJson, json_encode($hexadecimal));
+        self::assertSame($expectedJson, json_encode($hexadecimal));
     }
 }

--- a/tests/Type/IntegerTest.php
+++ b/tests/Type/IntegerTest.php
@@ -24,9 +24,9 @@ class IntegerTest extends TestCase
     {
         $integer = new IntegerObject($value);
 
-        $this->assertSame($expected, $integer->toString());
-        $this->assertSame($expected, (string) $integer);
-        $this->assertSame($expectedIsNegative, $integer->isNegative());
+        self::assertSame($expected, $integer->toString());
+        self::assertSame($expected, (string) $integer);
+        self::assertSame($expectedIsNegative, $integer->isNegative());
     }
 
     /**
@@ -205,7 +205,7 @@ class IntegerTest extends TestCase
         $serializedInteger = serialize($integer);
         $unserializedInteger = unserialize($serializedInteger);
 
-        $this->assertSame($expected, $unserializedInteger->toString());
+        self::assertSame($expected, $unserializedInteger->toString());
     }
 
     /**
@@ -218,6 +218,6 @@ class IntegerTest extends TestCase
         $integer = new IntegerObject($value);
         $expectedJson = sprintf('"%s"', $expected);
 
-        $this->assertSame($expectedJson, json_encode($integer));
+        self::assertSame($expectedJson, json_encode($integer));
     }
 }

--- a/tests/Type/TimeTest.php
+++ b/tests/Type/TimeTest.php
@@ -34,14 +34,14 @@ class TimeTest extends TestCase
 
         $time = new Time(...$params);
 
-        $this->assertSame((string) $seconds, $time->getSeconds()->toString());
+        self::assertSame((string) $seconds, $time->getSeconds()->toString());
 
-        $this->assertSame(
+        self::assertSame(
             (string) $microseconds ?: '0',
             $time->getMicroseconds()->toString()
         );
 
-        $this->assertSame($timeString, (string) $time);
+        self::assertSame($timeString, (string) $time);
     }
 
     /**
@@ -78,9 +78,9 @@ class TimeTest extends TestCase
         $serializedTime = serialize($time);
         $unserializedTime = unserialize($serializedTime);
 
-        $this->assertSame((string) $seconds, $unserializedTime->getSeconds()->toString());
+        self::assertSame((string) $seconds, $unserializedTime->getSeconds()->toString());
 
-        $this->assertSame(
+        self::assertSame(
             (string) $microseconds ?: '0',
             $unserializedTime->getMicroseconds()->toString()
         );
@@ -118,6 +118,6 @@ class TimeTest extends TestCase
 
         $time = new Time(...$params);
 
-        $this->assertSame($expectedJson, json_encode($time));
+        self::assertSame($expectedJson, json_encode($time));
     }
 }

--- a/tests/UuidFactoryTest.php
+++ b/tests/UuidFactoryTest.php
@@ -35,8 +35,8 @@ class UuidFactoryTest extends TestCase
 
         $uuid = $factory->fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
 
-        $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
-        $this->assertSame(hex2bin('ff6f8cb0c57d11e19b210800200c9a66'), $uuid->getBytes());
+        self::assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
+        self::assertSame(hex2bin('ff6f8cb0c57d11e19b210800200c9a66'), $uuid->getBytes());
     }
 
     public function testParsesGuidCorrectly(): void
@@ -45,8 +45,8 @@ class UuidFactoryTest extends TestCase
 
         $uuid = $factory->fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
 
-        $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
-        $this->assertSame(hex2bin('b08c6fff7dc5e1119b210800200c9a66'), $uuid->getBytes());
+        self::assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
+        self::assertSame(hex2bin('b08c6fff7dc5e1119b210800200c9a66'), $uuid->getBytes());
     }
 
     public function testFromStringParsesUuidInLowercase(): void
@@ -57,7 +57,7 @@ class UuidFactoryTest extends TestCase
 
         $uuid = $factory->fromString($uuidUpper);
 
-        $this->assertSame($uuidString, $uuid->toString());
+        self::assertSame($uuidString, $uuid->toString());
     }
 
     public function testGettersReturnValueFromFeatureSet(): void
@@ -87,25 +87,25 @@ class UuidFactoryTest extends TestCase
         ]);
 
         $uuidFactory = new UuidFactory($featureSet);
-        $this->assertSame(
+        self::assertSame(
             $codec,
             $uuidFactory->getCodec(),
             'getCodec did not return CodecInterface from FeatureSet'
         );
 
-        $this->assertSame(
+        self::assertSame(
             $nodeProvider,
             $uuidFactory->getNodeProvider(),
             'getNodeProvider did not return NodeProviderInterface from FeatureSet'
         );
 
-        $this->assertSame(
+        self::assertSame(
             $randomGenerator,
             $uuidFactory->getRandomGenerator(),
             'getRandomGenerator did not return RandomGeneratorInterface from FeatureSet'
         );
 
-        $this->assertSame(
+        self::assertSame(
             $timeGenerator,
             $uuidFactory->getTimeGenerator(),
             'getTimeGenerator did not return TimeGeneratorInterface from FeatureSet'
@@ -119,22 +119,22 @@ class UuidFactoryTest extends TestCase
         /** @var MockObject & CodecInterface $codec */
         $codec = $this->getMockBuilder(CodecInterface::class)->getMock();
         $uuidFactory->setCodec($codec);
-        $this->assertSame($codec, $uuidFactory->getCodec());
+        self::assertSame($codec, $uuidFactory->getCodec());
 
         /** @var MockObject & TimeGeneratorInterface $timeGenerator */
         $timeGenerator = $this->getMockBuilder(TimeGeneratorInterface::class)->getMock();
         $uuidFactory->setTimeGenerator($timeGenerator);
-        $this->assertSame($timeGenerator, $uuidFactory->getTimeGenerator());
+        self::assertSame($timeGenerator, $uuidFactory->getTimeGenerator());
 
         /** @var MockObject & NumberConverterInterface $numberConverter */
         $numberConverter = $this->getMockBuilder(NumberConverterInterface::class)->getMock();
         $uuidFactory->setNumberConverter($numberConverter);
-        $this->assertSame($numberConverter, $uuidFactory->getNumberConverter());
+        self::assertSame($numberConverter, $uuidFactory->getNumberConverter());
 
         /** @var MockObject & UuidBuilderInterface $uuidBuilder */
         $uuidBuilder = $this->getMockBuilder(UuidBuilderInterface::class)->getMock();
         $uuidFactory->setUuidBuilder($uuidBuilder);
-        $this->assertSame($uuidBuilder, $uuidFactory->getUuidBuilder());
+        self::assertSame($uuidBuilder, $uuidFactory->getUuidBuilder());
     }
 
     /**
@@ -151,8 +151,8 @@ class UuidFactoryTest extends TestCase
 
         $uuid = $factory->fromDateTime($dateTime, $node, $clockSeq);
 
-        $this->assertStringMatchesFormat($expectedUuidFormat, $uuid->toString());
-        $this->assertSame($expectedTime, $uuid->getDateTime()->format('U.u'));
+        self::assertStringMatchesFormat($expectedUuidFormat, $uuid->toString());
+        self::assertSame($expectedTime, $uuid->getDateTime()->format('U.u'));
     }
 
     /**
@@ -210,18 +210,18 @@ class UuidFactoryTest extends TestCase
     {
         $factory = new UuidFactory();
 
-        $this->assertInstanceOf(DefaultNameGenerator::class, $factory->getNameGenerator());
+        self::assertInstanceOf(DefaultNameGenerator::class, $factory->getNameGenerator());
     }
 
     public function testFactoryReturnsSetNameGenerator(): void
     {
         $factory = new UuidFactory();
 
-        $this->assertInstanceOf(DefaultNameGenerator::class, $factory->getNameGenerator());
+        self::assertInstanceOf(DefaultNameGenerator::class, $factory->getNameGenerator());
 
         $nameGenerator = Mockery::mock(NameGeneratorInterface::class);
         $factory->setNameGenerator($nameGenerator);
 
-        $this->assertSame($nameGenerator, $factory->getNameGenerator());
+        self::assertSame($nameGenerator, $factory->getNameGenerator());
     }
 }

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -62,7 +62,7 @@ class UuidTest extends TestCase
 
     public function testFromString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             'ff6f8cb0-c57d-11e1-9b21-0800200c9a66',
             Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66')
                 ->toString()
@@ -82,16 +82,16 @@ class UuidTest extends TestCase
         $guid = Guid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
 
         // UUID's and GUID's share the same textual representation.
-        $this->assertSame($uuid->toString(), $guid->toString());
+        self::assertSame($uuid->toString(), $guid->toString());
 
         // But not the same binary representation.
-        $this->assertNotSame($uuid->getBytes(), $guid->getBytes());
+        self::assertNotSame($uuid->getBytes(), $guid->getBytes());
     }
 
     public function testFromStringWithCurlyBraces(): void
     {
         $uuid = Uuid::fromString('{ff6f8cb0-c57d-11e1-9b21-0800200c9a66}');
-        $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
+        self::assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
     }
 
     public function testFromStringWithInvalidUuidString(): void
@@ -121,138 +121,138 @@ class UuidTest extends TestCase
     public function testFromStringWithUrn(): void
     {
         $uuid = Uuid::fromString('urn:uuid:ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
+        self::assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
     }
 
     public function testGetBytes(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame(16, strlen($uuid->getBytes()));
-        $this->assertSame('/2+MsMV9EeGbIQgAIAyaZg==', base64_encode($uuid->getBytes()));
+        self::assertSame(16, strlen($uuid->getBytes()));
+        self::assertSame('/2+MsMV9EeGbIQgAIAyaZg==', base64_encode($uuid->getBytes()));
     }
 
     public function testGetClockSeqHiAndReserved(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('155', $uuid->getClockSeqHiAndReserved());
+        self::assertSame('155', $uuid->getClockSeqHiAndReserved());
     }
 
     public function testGetClockSeqHiAndReservedHex(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('9b', $uuid->getClockSeqHiAndReservedHex());
+        self::assertSame('9b', $uuid->getClockSeqHiAndReservedHex());
     }
 
     public function testGetClockSeqLow(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('33', $uuid->getClockSeqLow());
+        self::assertSame('33', $uuid->getClockSeqLow());
     }
 
     public function testGetClockSeqLowHex(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('21', $uuid->getClockSeqLowHex());
+        self::assertSame('21', $uuid->getClockSeqLowHex());
     }
 
     public function testGetClockSequence(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('6945', $uuid->getClockSequence());
+        self::assertSame('6945', $uuid->getClockSequence());
     }
 
     public function testGetClockSequenceHex(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('1b21', $uuid->getClockSequenceHex());
+        self::assertSame('1b21', $uuid->getClockSequenceHex());
     }
 
     public function testGetDateTime(): void
     {
         // Check a recent date
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('2012-07-04T02:14:34+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('1341368074.491000', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('2012-07-04T02:14:34+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('1341368074.491000', $uuid->getDateTime()->format('U.u'));
 
         // Check an old date
         $uuid = Uuid::fromString('0901e600-0154-1000-9b21-0800200c9a66');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('1582-10-16T16:34:04+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('-12219146756.000000', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('1582-10-16T16:34:04+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('-12219146756.000000', $uuid->getDateTime()->format('U.u'));
 
         // Check a future date
         $uuid = Uuid::fromString('ff9785f6-ffff-1fff-9669-00007ffffffe');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('5236-03-31T21:20:59+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('103072857659.999999', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('5236-03-31T21:20:59+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('103072857659.999999', $uuid->getDateTime()->format('U.u'));
 
         // Check the last possible time supported by v1 UUIDs
         // See inline comments in
         // {@see \Ramsey\Uuid\Test\Converter\Time\GenericTimeConverterTest::provideCalculateTime()}
         $uuid = Uuid::fromString('fffffffa-ffff-1fff-8b1e-acde48001122');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('5236-03-31T21:21:00+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('103072857660.684697', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('5236-03-31T21:21:00+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('103072857660.684697', $uuid->getDateTime()->format('U.u'));
 
         // Check the oldest date
         $uuid = Uuid::fromString('00000000-0000-1000-9669-00007ffffffe');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('1582-10-15T00:00:00+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('-12219292800.000000', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('1582-10-15T00:00:00+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('-12219292800.000000', $uuid->getDateTime()->format('U.u'));
 
         // The Unix epoch
         $uuid = Uuid::fromString('13814000-1dd2-11b2-9669-00007ffffffe');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('1970-01-01T00:00:00+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('0.000000', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('1970-01-01T00:00:00+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('0.000000', $uuid->getDateTime()->format('U.u'));
     }
 
     public function testGetDateTimeForUuidV6(): void
     {
         // Check a recent date
         $uuid = Uuid::fromString('1e1c57df-f6f8-6cb0-9b21-0800200c9a66');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('2012-07-04T02:14:34+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('1341368074.491000', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('2012-07-04T02:14:34+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('1341368074.491000', $uuid->getDateTime()->format('U.u'));
 
         // Check an old date
         $uuid = Uuid::fromString('00001540-901e-6600-9b21-0800200c9a66');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('1582-10-16T16:34:04+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('-12219146756.000000', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('1582-10-16T16:34:04+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('-12219146756.000000', $uuid->getDateTime()->format('U.u'));
 
         // Check a future date
         $uuid = Uuid::fromString('ffffffff-f978-65f6-9669-00007ffffffe');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('5236-03-31T21:20:59+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('103072857659.999999', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('5236-03-31T21:20:59+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('103072857659.999999', $uuid->getDateTime()->format('U.u'));
 
         // Check the last possible time supported by UUIDs
         // See inline comments in
         // {@see \Ramsey\Uuid\Test\Converter\Time\GenericTimeConverterTest::provideCalculateTime()}
         $uuid = Uuid::fromString('ffffffff-ffff-6ffa-8b1e-acde48001122');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('5236-03-31T21:21:00+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('103072857660.684697', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('5236-03-31T21:21:00+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('103072857660.684697', $uuid->getDateTime()->format('U.u'));
 
         // Check the oldest date
         $uuid = Uuid::fromString('00000000-0000-6000-9669-00007ffffffe');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('1582-10-15T00:00:00+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('-12219292800.000000', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('1582-10-15T00:00:00+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('-12219292800.000000', $uuid->getDateTime()->format('U.u'));
 
         // The Unix epoch
         $uuid = Uuid::fromString('1b21dd21-3814-6000-9669-00007ffffffe');
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame('1970-01-01T00:00:00+00:00', $uuid->getDateTime()->format('c'));
-        $this->assertSame('0.000000', $uuid->getDateTime()->format('U.u'));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame('1970-01-01T00:00:00+00:00', $uuid->getDateTime()->format('c'));
+        self::assertSame('0.000000', $uuid->getDateTime()->format('U.u'));
     }
 
     public function testGetDateTimeFromNonVersion1Uuid(): void
@@ -271,7 +271,7 @@ class UuidTest extends TestCase
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
 
-        $this->assertInstanceOf(FieldsInterface::class, $uuid->getFields());
+        self::assertInstanceOf(FieldsInterface::class, $uuid->getFields());
     }
 
     public function testGetFieldsHex(): void
@@ -287,7 +287,7 @@ class UuidTest extends TestCase
 
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
 
-        $this->assertSame($fields, $uuid->getFieldsHex());
+        self::assertSame($fields, $uuid->getFieldsHex());
     }
 
     public function testGetLeastSignificantBits(): void
@@ -295,14 +295,14 @@ class UuidTest extends TestCase
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
 
-        $this->assertSame('11178224546741000806', $uuid->getLeastSignificantBits());
+        self::assertSame('11178224546741000806', $uuid->getLeastSignificantBits());
     }
 
     public function testGetLeastSignificantBitsHex(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
 
-        $this->assertSame('9b210800200c9a66', $uuid->getLeastSignificantBitsHex());
+        self::assertSame('9b210800200c9a66', $uuid->getLeastSignificantBitsHex());
     }
 
     public function testGetMostSignificantBits(): void
@@ -310,65 +310,65 @@ class UuidTest extends TestCase
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
 
-        $this->assertSame('18406084892941947361', $uuid->getMostSignificantBits());
+        self::assertSame('18406084892941947361', $uuid->getMostSignificantBits());
     }
 
     public function testGetMostSignificantBitsHex(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('ff6f8cb0c57d11e1', $uuid->getMostSignificantBitsHex());
+        self::assertSame('ff6f8cb0c57d11e1', $uuid->getMostSignificantBitsHex());
     }
 
     public function testGetNode(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('8796630719078', $uuid->getNode());
+        self::assertSame('8796630719078', $uuid->getNode());
     }
 
     public function testGetNodeHex(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('0800200c9a66', $uuid->getNodeHex());
+        self::assertSame('0800200c9a66', $uuid->getNodeHex());
     }
 
     public function testGetTimeHiAndVersion(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('4577', $uuid->getTimeHiAndVersion());
+        self::assertSame('4577', $uuid->getTimeHiAndVersion());
     }
 
     public function testGetTimeHiAndVersionHex(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('11e1', $uuid->getTimeHiAndVersionHex());
+        self::assertSame('11e1', $uuid->getTimeHiAndVersionHex());
     }
 
     public function testGetTimeLow(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('4285500592', $uuid->getTimeLow());
+        self::assertSame('4285500592', $uuid->getTimeLow());
     }
 
     public function testGetTimeLowHex(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('ff6f8cb0', $uuid->getTimeLowHex());
+        self::assertSame('ff6f8cb0', $uuid->getTimeLowHex());
     }
 
     public function testGetTimeMid(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('50557', $uuid->getTimeMid());
+        self::assertSame('50557', $uuid->getTimeMid());
     }
 
     public function testGetTimeMidHex(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('c57d', $uuid->getTimeMidHex());
+        self::assertSame('c57d', $uuid->getTimeMidHex());
     }
 
     public function testGetTimestamp(): void
@@ -376,23 +376,23 @@ class UuidTest extends TestCase
         // Check for a recent date
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('135606608744910000', $uuid->getTimestamp());
+        self::assertSame('135606608744910000', $uuid->getTimestamp());
 
         // Check for an old date
         /** @var Uuid $uuid */
         $uuid = Uuid::fromString('0901e600-0154-1000-9b21-0800200c9a66');
-        $this->assertSame('1460440000000', $uuid->getTimestamp());
+        self::assertSame('1460440000000', $uuid->getTimestamp());
     }
 
     public function testGetTimestampHex(): void
     {
         // Check for a recent date
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('1e1c57dff6f8cb0', $uuid->getTimestampHex());
+        self::assertSame('1e1c57dff6f8cb0', $uuid->getTimestampHex());
 
         // Check for an old date
         $uuid = Uuid::fromString('0901e600-0154-1000-9b21-0800200c9a66');
-        $this->assertSame('00001540901e600', $uuid->getTimestampHex());
+        self::assertSame('00001540901e600', $uuid->getTimestampHex());
     }
 
     public function testGetTimestampFromNonVersion1Uuid(): void
@@ -421,7 +421,7 @@ class UuidTest extends TestCase
     public function testGetUrn(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('urn:uuid:ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->getUrn());
+        self::assertSame('urn:uuid:ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->getUrn());
     }
 
     /**
@@ -430,7 +430,7 @@ class UuidTest extends TestCase
     public function testGetVariantForVariousVariantUuids(string $uuid, int $variant): void
     {
         $uuid = Uuid::fromString($uuid);
-        $this->assertSame($variant, $uuid->getVariant());
+        self::assertSame($variant, $uuid->getVariant());
     }
 
     /**
@@ -461,76 +461,76 @@ class UuidTest extends TestCase
     public function testGetVersionForVersion1(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame(1, $uuid->getVersion());
+        self::assertSame(1, $uuid->getVersion());
     }
 
     public function testGetVersionForVersion2(): void
     {
         $uuid = Uuid::fromString('6fa459ea-ee8a-2ca4-894e-db77e160355e');
-        $this->assertSame(2, $uuid->getVersion());
+        self::assertSame(2, $uuid->getVersion());
     }
 
     public function testGetVersionForVersion3(): void
     {
         $uuid = Uuid::fromString('6fa459ea-ee8a-3ca4-894e-db77e160355e');
-        $this->assertSame(3, $uuid->getVersion());
+        self::assertSame(3, $uuid->getVersion());
     }
 
     public function testGetVersionForVersion4(): void
     {
         $uuid = Uuid::fromString('6fabf0bc-603a-42f2-925b-d9f779bd0032');
-        $this->assertSame(4, $uuid->getVersion());
+        self::assertSame(4, $uuid->getVersion());
     }
 
     public function testGetVersionForVersion5(): void
     {
         $uuid = Uuid::fromString('886313e1-3b8a-5372-9b90-0c9aee199e5d');
-        $this->assertSame(5, $uuid->getVersion());
+        self::assertSame(5, $uuid->getVersion());
     }
 
     public function testToString(): void
     {
         // Check with a recent date
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
-        $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', (string) $uuid);
+        self::assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
+        self::assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', (string) $uuid);
 
         // Check with an old date
         $uuid = Uuid::fromString('0901e600-0154-1000-9b21-0800200c9a66');
-        $this->assertSame('0901e600-0154-1000-9b21-0800200c9a66', $uuid->toString());
-        $this->assertSame('0901e600-0154-1000-9b21-0800200c9a66', (string) $uuid);
+        self::assertSame('0901e600-0154-1000-9b21-0800200c9a66', $uuid->toString());
+        self::assertSame('0901e600-0154-1000-9b21-0800200c9a66', (string) $uuid);
     }
 
     public function testUuid1(): void
     {
         $uuid = Uuid::uuid1();
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(1, $uuid->getVersion());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(1, $uuid->getVersion());
     }
 
     public function testUuid1WithNodeAndClockSequence(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::uuid1('0800200c9a66', 0x1669);
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(1, $uuid->getVersion());
-        $this->assertSame('5737', $uuid->getClockSequence());
-        $this->assertSame('8796630719078', $uuid->getNode());
-        $this->assertSame('9669-0800200c9a66', substr($uuid->toString(), 19));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(1, $uuid->getVersion());
+        self::assertSame('5737', $uuid->getClockSequence());
+        self::assertSame('8796630719078', $uuid->getNode());
+        self::assertSame('9669-0800200c9a66', substr($uuid->toString(), 19));
     }
 
     public function testUuid1WithHexadecimalObjectNodeAndClockSequence(): void
     {
         /** @var Uuid $uuid */
         $uuid = Uuid::uuid1(new Hexadecimal('0800200c9a66'), 0x1669);
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(1, $uuid->getVersion());
-        $this->assertSame('5737', $uuid->getClockSequence());
-        $this->assertSame('8796630719078', $uuid->getNode());
-        $this->assertSame('9669-0800200c9a66', substr($uuid->toString(), 19));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(1, $uuid->getVersion());
+        self::assertSame('5737', $uuid->getClockSequence());
+        self::assertSame('8796630719078', $uuid->getNode());
+        self::assertSame('9669-0800200c9a66', substr($uuid->toString(), 19));
     }
 
     public function testUuid1WithHexadecimalNode(): void
@@ -538,11 +538,11 @@ class UuidTest extends TestCase
         /** @var Uuid $uuid */
         $uuid = Uuid::uuid1('7160355e');
 
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(1, $uuid->getVersion());
-        $this->assertSame('00007160355e', $uuid->getNodeHex());
-        $this->assertSame('1902130526', $uuid->getNode());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(1, $uuid->getVersion());
+        self::assertSame('00007160355e', $uuid->getNodeHex());
+        self::assertSame('1902130526', $uuid->getNode());
     }
 
     public function testUuid1WithHexadecimalObjectNode(): void
@@ -550,11 +550,11 @@ class UuidTest extends TestCase
         /** @var Uuid $uuid */
         $uuid = Uuid::uuid1(new Hexadecimal('7160355e'));
 
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(1, $uuid->getVersion());
-        $this->assertSame('00007160355e', $uuid->getNodeHex());
-        $this->assertSame('1902130526', $uuid->getNode());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(1, $uuid->getVersion());
+        self::assertSame('00007160355e', $uuid->getNodeHex());
+        self::assertSame('1902130526', $uuid->getNode());
     }
 
     public function testUuid1WithMixedCaseHexadecimalNode(): void
@@ -562,11 +562,11 @@ class UuidTest extends TestCase
         /** @var Uuid $uuid */
         $uuid = Uuid::uuid1('71B0aD5e');
 
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(1, $uuid->getVersion());
-        $this->assertSame('000071b0ad5e', $uuid->getNodeHex());
-        $this->assertSame('1907404126', $uuid->getNode());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(1, $uuid->getVersion());
+        self::assertSame('000071b0ad5e', $uuid->getNodeHex());
+        self::assertSame('1907404126', $uuid->getNode());
     }
 
     public function testUuid1WithOutOfBoundsNode(): void
@@ -598,56 +598,56 @@ class UuidTest extends TestCase
         Uuid::setFactory(new UuidFactory(new FeatureSet(false, false, false, true)));
 
         $uuid = Uuid::uuid1();
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(1, $uuid->getVersion());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(1, $uuid->getVersion());
     }
 
     public function testUuid1WithUserGeneratedRandomNode(): void
     {
         $uuid = Uuid::uuid1(new Hexadecimal((string) (new RandomNodeProvider())->getNode()));
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(1, $uuid->getVersion());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(1, $uuid->getVersion());
     }
 
     public function testUuid6(): void
     {
         $uuid = Uuid::uuid6();
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(6, $uuid->getVersion());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(6, $uuid->getVersion());
     }
 
     public function testUuid6WithNodeAndClockSequence(): void
     {
         $uuid = Uuid::uuid6(new Hexadecimal('0800200c9a66'), 0x1669);
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(6, $uuid->getVersion());
-        $this->assertSame('1669', $uuid->getClockSequenceHex());
-        $this->assertSame('0800200c9a66', $uuid->getNodeHex());
-        $this->assertSame('9669-0800200c9a66', substr($uuid->toString(), 19));
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(6, $uuid->getVersion());
+        self::assertSame('1669', $uuid->getClockSequenceHex());
+        self::assertSame('0800200c9a66', $uuid->getNodeHex());
+        self::assertSame('9669-0800200c9a66', substr($uuid->toString(), 19));
     }
 
     public function testUuid6WithHexadecimalNode(): void
     {
         $uuid = Uuid::uuid6(new Hexadecimal('7160355e'));
 
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(6, $uuid->getVersion());
-        $this->assertSame('00007160355e', $uuid->getNodeHex());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(6, $uuid->getVersion());
+        self::assertSame('00007160355e', $uuid->getNodeHex());
     }
 
     public function testUuid6WithMixedCaseHexadecimalNode(): void
     {
         $uuid = Uuid::uuid6(new Hexadecimal('71B0aD5e'));
 
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(6, $uuid->getVersion());
-        $this->assertSame('000071b0ad5e', $uuid->getNodeHex());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(6, $uuid->getVersion());
+        self::assertSame('000071b0ad5e', $uuid->getNodeHex());
     }
 
     public function testUuid6WithOutOfBoundsNode(): void
@@ -671,17 +671,17 @@ class UuidTest extends TestCase
         Uuid::setFactory(new UuidFactory(new FeatureSet(false, false, false, true)));
 
         $uuid = Uuid::uuid6();
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(6, $uuid->getVersion());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(6, $uuid->getVersion());
     }
 
     public function testUuid6WithUserGeneratedRandomNode(): void
     {
         $uuid = Uuid::uuid6(new Hexadecimal((string) (new RandomNodeProvider())->getNode()));
-        $this->assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(6, $uuid->getVersion());
+        self::assertInstanceOf(DateTimeInterface::class, $uuid->getDateTime());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(6, $uuid->getVersion());
     }
 
     /**
@@ -697,10 +697,10 @@ class UuidTest extends TestCase
         $uobj1 = Uuid::uuid3($ns, $name);
         $uobj2 = Uuid::uuid3(Uuid::fromString($ns), $name);
 
-        $this->assertSame(2, $uobj1->getVariant());
-        $this->assertSame(3, $uobj1->getVersion());
-        $this->assertSame(Uuid::fromString($uuid)->toString(), $uobj1->toString());
-        $this->assertTrue($uobj1->equals($uobj2));
+        self::assertSame(2, $uobj1->getVariant());
+        self::assertSame(3, $uobj1->getVersion());
+        self::assertSame(Uuid::fromString($uuid)->toString(), $uobj1->toString());
+        self::assertTrue($uobj1->equals($uobj2));
     }
 
     /**
@@ -735,8 +735,8 @@ class UuidTest extends TestCase
     public function testUuid4(): void
     {
         $uuid = Uuid::uuid4();
-        $this->assertSame(2, $uuid->getVariant());
-        $this->assertSame(4, $uuid->getVersion());
+        self::assertSame(2, $uuid->getVariant());
+        self::assertSame(4, $uuid->getVersion());
     }
 
     /**
@@ -745,7 +745,7 @@ class UuidTest extends TestCase
     public function testUuid4TimestampLastComb(): void
     {
         $mock = $this->getMockBuilder(RandomGeneratorInterface::class)->getMock();
-        $mock->expects($this->any())
+        $mock->expects(self::any())
             ->method('generate')
             ->willReturnCallback(function ($length) {
                 // Makes first fields of UUIDs equal
@@ -763,7 +763,7 @@ class UuidTest extends TestCase
         for ($i = 0; $i < 1000; $i++) {
             usleep(100);
             $uuid = $factory->uuid4();
-            $this->assertGreaterThan($previous->toString(), $uuid->toString());
+            self::assertGreaterThan($previous->toString(), $uuid->toString());
 
             $previous = $uuid;
         }
@@ -775,7 +775,7 @@ class UuidTest extends TestCase
     public function testUuid4TimestampFirstComb(): void
     {
         $mock = $this->getMockBuilder(RandomGeneratorInterface::class)->getMock();
-        $mock->expects($this->any())
+        $mock->expects(self::any())
             ->method('generate')
             ->willReturnCallback(function ($length) {
                 // Makes first fields of UUIDs equal
@@ -793,7 +793,7 @@ class UuidTest extends TestCase
         for ($i = 0; $i < 1000; $i++) {
             usleep(100);
             $uuid = $factory->uuid4();
-            $this->assertGreaterThan($previous->toString(), $uuid->toString());
+            self::assertGreaterThan($previous->toString(), $uuid->toString());
 
             $previous = $uuid;
         }
@@ -814,7 +814,7 @@ class UuidTest extends TestCase
 
         $uuid = $factory->uuid4();
 
-        $this->assertSame(4, $uuid->getVersion());
+        self::assertSame(4, $uuid->getVersion());
     }
 
     /**
@@ -830,10 +830,10 @@ class UuidTest extends TestCase
         $uobj1 = Uuid::uuid5($ns, $name);
         $uobj2 = Uuid::uuid5(Uuid::fromString($ns), $name);
 
-        $this->assertSame(2, $uobj1->getVariant());
-        $this->assertSame(5, $uobj1->getVersion());
-        $this->assertSame(Uuid::fromString($uuid)->toString(), $uobj1->toString());
-        $this->assertTrue($uobj1->equals($uobj2));
+        self::assertSame(2, $uobj1->getVariant());
+        self::assertSame(5, $uobj1->getVersion());
+        self::assertSame(Uuid::fromString($uuid)->toString(), $uobj1->toString());
+        self::assertTrue($uobj1->equals($uobj2));
     }
 
     /**
@@ -883,12 +883,12 @@ class UuidTest extends TestCase
         // msb are equal to those in $uuid3, lsb are less than in $uuid3
         $uuid5 = Uuid::fromString('44cca71e-d13d-11e1-a959-c8bcc8a476f3');
 
-        $this->assertSame(0, $uuid1->compareTo($uuid2));
-        $this->assertSame(0, $uuid2->compareTo($uuid1));
-        $this->assertSame(-1, $uuid3->compareTo($uuid4));
-        $this->assertSame(1, $uuid4->compareTo($uuid3));
-        $this->assertSame(-1, $uuid5->compareTo($uuid3));
-        $this->assertSame(1, $uuid3->compareTo($uuid5));
+        self::assertSame(0, $uuid1->compareTo($uuid2));
+        self::assertSame(0, $uuid2->compareTo($uuid1));
+        self::assertSame(-1, $uuid3->compareTo($uuid4));
+        self::assertSame(1, $uuid4->compareTo($uuid3));
+        self::assertSame(-1, $uuid5->compareTo($uuid3));
+        self::assertSame(1, $uuid3->compareTo($uuid5));
     }
 
     public function testCompareToReturnsZeroWhenDifferentCases(): void
@@ -898,8 +898,8 @@ class UuidTest extends TestCase
         $uuid1 = Uuid::fromString($uuidString);
         $uuid2 = Uuid::fromString(strtoupper($uuidString));
 
-        $this->assertSame(0, $uuid1->compareTo($uuid2));
-        $this->assertSame(0, $uuid2->compareTo($uuid1));
+        self::assertSame(0, $uuid1->compareTo($uuid2));
+        self::assertSame(0, $uuid2->compareTo($uuid1));
     }
 
     public function testEqualsReturnsTrueWhenDifferentCases(): void
@@ -909,8 +909,8 @@ class UuidTest extends TestCase
         $uuid1 = Uuid::fromString($uuidString);
         $uuid2 = Uuid::fromString(strtoupper($uuidString));
 
-        $this->assertTrue($uuid1->equals($uuid2));
-        $this->assertTrue($uuid2->equals($uuid1));
+        self::assertTrue($uuid1->equals($uuid2));
+        self::assertTrue($uuid2->equals($uuid1));
     }
 
     public function testEquals(): void
@@ -919,9 +919,9 @@ class UuidTest extends TestCase
         $uuid2 = Uuid::uuid5(Uuid::NAMESPACE_DNS, 'python.org');
         $uuid3 = Uuid::uuid5(Uuid::NAMESPACE_DNS, 'php.net');
 
-        $this->assertTrue($uuid1->equals($uuid2));
-        $this->assertFalse($uuid1->equals($uuid3));
-        $this->assertFalse($uuid1->equals(new stdClass()));
+        self::assertTrue($uuid1->equals($uuid2));
+        self::assertFalse($uuid1->equals($uuid3));
+        self::assertFalse($uuid1->equals(new stdClass()));
     }
 
     public function testCalculateUuidTime(): void
@@ -935,28 +935,28 @@ class UuidTest extends TestCase
         Uuid::setFactory(new UuidFactory($featureSet));
         $uuidA = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertSame('c4dbe7e2-097f-11e2-9669-00007ffffffe', (string) $uuidA);
-        $this->assertSame('c4dbe7e2', $uuidA->getTimeLowHex());
-        $this->assertSame('097f', $uuidA->getTimeMidHex());
-        $this->assertSame('11e2', $uuidA->getTimeHiAndVersionHex());
+        self::assertSame('c4dbe7e2-097f-11e2-9669-00007ffffffe', (string) $uuidA);
+        self::assertSame('c4dbe7e2', $uuidA->getTimeLowHex());
+        self::assertSame('097f', $uuidA->getTimeMidHex());
+        self::assertSame('11e2', $uuidA->getTimeHiAndVersionHex());
 
         // For usec = 0
         $timeOfDay->setUsec(0);
         $uuidB = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertSame('c4b18100-097f-11e2-9669-00007ffffffe', (string) $uuidB);
-        $this->assertSame('c4b18100', $uuidB->getTimeLowHex());
-        $this->assertSame('097f', $uuidB->getTimeMidHex());
-        $this->assertSame('11e2', $uuidB->getTimeHiAndVersionHex());
+        self::assertSame('c4b18100-097f-11e2-9669-00007ffffffe', (string) $uuidB);
+        self::assertSame('c4b18100', $uuidB->getTimeLowHex());
+        self::assertSame('097f', $uuidB->getTimeMidHex());
+        self::assertSame('11e2', $uuidB->getTimeHiAndVersionHex());
 
         // For usec = 999999
         $timeOfDay->setUsec(999999);
         $uuidC = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertSame('c54a1776-097f-11e2-9669-00007ffffffe', (string) $uuidC);
-        $this->assertSame('c54a1776', $uuidC->getTimeLowHex());
-        $this->assertSame('097f', $uuidC->getTimeMidHex());
-        $this->assertSame('11e2', $uuidC->getTimeHiAndVersionHex());
+        self::assertSame('c54a1776-097f-11e2-9669-00007ffffffe', (string) $uuidC);
+        self::assertSame('c54a1776', $uuidC->getTimeLowHex());
+        self::assertSame('097f', $uuidC->getTimeMidHex());
+        self::assertSame('11e2', $uuidC->getTimeHiAndVersionHex());
     }
 
     public function testCalculateUuidTimeUpperLowerBounds(): void
@@ -970,10 +970,10 @@ class UuidTest extends TestCase
         Uuid::setFactory(new UuidFactory($featureSet));
         $uuidA = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertSame('ff9785f6-ffff-1fff-9669-00007ffffffe', (string) $uuidA);
-        $this->assertSame('ff9785f6', $uuidA->getTimeLowHex());
-        $this->assertSame('ffff', $uuidA->getTimeMidHex());
-        $this->assertSame('1fff', $uuidA->getTimeHiAndVersionHex());
+        self::assertSame('ff9785f6-ffff-1fff-9669-00007ffffffe', (string) $uuidA);
+        self::assertSame('ff9785f6', $uuidA->getTimeLowHex());
+        self::assertSame('ffff', $uuidA->getTimeMidHex());
+        self::assertSame('1fff', $uuidA->getTimeHiAndVersionHex());
 
         // 1582-10-15T00:00:00+00:00
         $timeOfDay = new FixedTimeProvider(new Time('-12219292800', '0'));
@@ -983,10 +983,10 @@ class UuidTest extends TestCase
         Uuid::setFactory(new UuidFactory($featureSet));
         $uuidB = Uuid::uuid1(0x00007ffffffe, 0x1669);
 
-        $this->assertSame('00000000-0000-1000-9669-00007ffffffe', (string) $uuidB);
-        $this->assertSame('00000000', $uuidB->getTimeLowHex());
-        $this->assertSame('0000', $uuidB->getTimeMidHex());
-        $this->assertSame('1000', $uuidB->getTimeHiAndVersionHex());
+        self::assertSame('00000000-0000-1000-9669-00007ffffffe', (string) $uuidB);
+        self::assertSame('00000000', $uuidB->getTimeLowHex());
+        self::assertSame('0000', $uuidB->getTimeMidHex());
+        self::assertSame('1000', $uuidB->getTimeHiAndVersionHex());
     }
 
     /**
@@ -1018,7 +1018,7 @@ class UuidTest extends TestCase
                 $uuid32 = $smallIntFactory->uuid1(0x00007ffffffe, 0x1669);
                 $uuid64 = $factory->uuid1(0x00007ffffffe, 0x1669);
 
-                $this->assertTrue(
+                self::assertTrue(
                     $uuid32->equals($uuid64),
                     'Breaks at ' . gmdate('r', $currentTime)
                         . "; 32-bit: {$uuid32->toString()}, 64-bit: {$uuid64->toString()}"
@@ -1027,8 +1027,8 @@ class UuidTest extends TestCase
                 // Assert that the time matches
                 $usecAdd = BigDecimal::of($usec)->dividedBy('1000000', 14, RoundingMode::HALF_UP);
                 $testTime = BigDecimal::of($currentTime)->plus($usecAdd)->toScale(0, RoundingMode::DOWN);
-                $this->assertSame((string) $testTime, (string) $uuid64->getDateTime()->getTimestamp());
-                $this->assertSame((string) $testTime, (string) $uuid32->getDateTime()->getTimestamp());
+                self::assertSame((string) $testTime, (string) $uuid64->getDateTime()->getTimestamp());
+                self::assertSame((string) $testTime, (string) $uuid32->getDateTime()->getTimestamp());
             }
 
             $currentTime++;
@@ -1044,13 +1044,13 @@ class UuidTest extends TestCase
 
         /** @var MockObject & ValidatorInterface $validator */
         $validator = $this->getMockBuilder(ValidatorInterface::class)->getMock();
-        $validator->expects($this->once())->method('validate')->with($argument)->willReturn(true);
+        $validator->expects(self::once())->method('validate')->with($argument)->willReturn(true);
 
         /** @var UuidFactory $factory */
         $factory = Uuid::getFactory();
         $factory->setValidator($validator);
 
-        $this->assertTrue(Uuid::isValid($argument));
+        self::assertTrue(Uuid::isValid($argument));
 
         // reset the static validator
         $factory->setValidator(new GenericValidator());
@@ -1077,7 +1077,7 @@ class UuidTest extends TestCase
 
         $fromBytesUuid = Uuid::fromBytes($bytes);
 
-        $this->assertTrue($uuid->equals($fromBytesUuid));
+        self::assertTrue($uuid->equals($fromBytesUuid));
     }
 
     public function testGuidBytesMatchesUuidWithSameString(): void
@@ -1096,8 +1096,8 @@ class UuidTest extends TestCase
 
         $guid = $guidFactory->fromBytes($guidBytes);
 
-        $this->assertSame($uuid->toString(), $guid->toString());
-        $this->assertTrue($uuid->equals($guid));
+        self::assertSame($uuid->toString(), $guid->toString());
+        self::assertTrue($uuid->equals($guid));
     }
 
     public function testGuidBytesProducesSameGuidString(): void
@@ -1109,8 +1109,8 @@ class UuidTest extends TestCase
 
         $parsedGuid = $guidFactory->fromBytes($bytes);
 
-        $this->assertSame($guid->toString(), $parsedGuid->toString());
-        $this->assertTrue($guid->equals($parsedGuid));
+        self::assertSame($guid->toString(), $parsedGuid->toString());
+        self::assertTrue($guid->equals($parsedGuid));
     }
 
     public function testFromBytesArgumentTooShort(): void
@@ -1134,7 +1134,7 @@ class UuidTest extends TestCase
 
         $fromIntegerUuid = Uuid::fromInteger($integer);
 
-        $this->assertTrue($uuid->equals($fromIntegerUuid));
+        self::assertTrue($uuid->equals($fromIntegerUuid));
     }
 
     public function testFromDateTime(): void
@@ -1145,7 +1145,7 @@ class UuidTest extends TestCase
 
         $fromDateTimeUuid = Uuid::fromDateTime($dateTime, new Hexadecimal('0800200c9a66'), 2849);
 
-        $this->assertTrue($uuid->equals($fromDateTimeUuid));
+        self::assertTrue($uuid->equals($fromDateTimeUuid));
     }
 
     /**
@@ -1180,24 +1180,24 @@ class UuidTest extends TestCase
 
         /** @var UuidInterface $uuid */
         foreach ($uuids as $uuid) {
-            $this->assertSame($string, $uuid->toString());
-            $this->assertSame($hex, $uuid->getHex()->toString());
-            $this->assertSame(base64_decode($bytes), $uuid->getBytes());
-            $this->assertSame($int, $uuid->getInteger()->toString());
-            $this->assertSame($fields, $uuid->getFieldsHex());
-            $this->assertSame($fields['time_low'], $uuid->getTimeLowHex());
-            $this->assertSame($fields['time_mid'], $uuid->getTimeMidHex());
-            $this->assertSame($fields['time_hi_and_version'], $uuid->getTimeHiAndVersionHex());
-            $this->assertSame($fields['clock_seq_hi_and_reserved'], $uuid->getClockSeqHiAndReservedHex());
-            $this->assertSame($fields['clock_seq_low'], $uuid->getClockSeqLowHex());
-            $this->assertSame($fields['node'], $uuid->getNodeHex());
-            $this->assertSame($urn, $uuid->getUrn());
+            self::assertSame($string, $uuid->toString());
+            self::assertSame($hex, $uuid->getHex()->toString());
+            self::assertSame(base64_decode($bytes), $uuid->getBytes());
+            self::assertSame($int, $uuid->getInteger()->toString());
+            self::assertSame($fields, $uuid->getFieldsHex());
+            self::assertSame($fields['time_low'], $uuid->getTimeLowHex());
+            self::assertSame($fields['time_mid'], $uuid->getTimeMidHex());
+            self::assertSame($fields['time_hi_and_version'], $uuid->getTimeHiAndVersionHex());
+            self::assertSame($fields['clock_seq_hi_and_reserved'], $uuid->getClockSeqHiAndReservedHex());
+            self::assertSame($fields['clock_seq_low'], $uuid->getClockSeqLowHex());
+            self::assertSame($fields['node'], $uuid->getNodeHex());
+            self::assertSame($urn, $uuid->getUrn());
             if ($uuid->getVersion() === 1) {
-                $this->assertSame($time, $uuid->getTimestampHex());
+                self::assertSame($time, $uuid->getTimestampHex());
             }
-            $this->assertSame($clockSeq, $uuid->getClockSequenceHex());
-            $this->assertSame($variant, $uuid->getVariant());
-            $this->assertSame($version, $uuid->getVersion());
+            self::assertSame($clockSeq, $uuid->getClockSequenceHex());
+            self::assertSame($variant, $uuid->getVariant());
+            self::assertSame($version, $uuid->getVersion());
         }
     }
 
@@ -1501,7 +1501,7 @@ class UuidTest extends TestCase
     {
         $uuid = Uuid::uuid1();
 
-        $this->assertSame('"' . $uuid->toString() . '"', json_encode($uuid));
+        self::assertSame('"' . $uuid->toString() . '"', json_encode($uuid));
     }
 
     public function testSerialize(): void
@@ -1509,7 +1509,7 @@ class UuidTest extends TestCase
         $uuid = Uuid::uuid4();
         $serialized = serialize($uuid);
         $unserializedUuid = unserialize($serialized);
-        $this->assertTrue($uuid->equals($unserializedUuid));
+        self::assertTrue($uuid->equals($unserializedUuid));
     }
 
     public function testSerializeWithOldStringFormat(): void
@@ -1519,7 +1519,7 @@ class UuidTest extends TestCase
         /** @var UuidInterface $unserializedUuid */
         $unserializedUuid = unserialize($serialized);
 
-        $this->assertSame('b3cd586a-e3ca-44f3-988c-f4d666c1bf4d', $unserializedUuid->toString());
+        self::assertSame('b3cd586a-e3ca-44f3-988c-f4d666c1bf4d', $unserializedUuid->toString());
     }
 
     public function testUuid3WithEmptyNamespace(): void
@@ -1534,14 +1534,14 @@ class UuidTest extends TestCase
     {
         $uuid = Uuid::uuid3(Uuid::NIL, '');
 
-        $this->assertSame('4ae71336-e44b-39bf-b9d2-752e234818a5', $uuid->toString());
+        self::assertSame('4ae71336-e44b-39bf-b9d2-752e234818a5', $uuid->toString());
     }
 
     public function testUuid3WithZeroName(): void
     {
         $uuid = Uuid::uuid3(Uuid::NIL, '0');
 
-        $this->assertSame('19826852-5007-3022-a72a-212f66e9fac3', $uuid->toString());
+        self::assertSame('19826852-5007-3022-a72a-212f66e9fac3', $uuid->toString());
     }
 
     public function testUuid5WithEmptyNamespace(): void
@@ -1556,14 +1556,14 @@ class UuidTest extends TestCase
     {
         $uuid = Uuid::uuid5(Uuid::NIL, '');
 
-        $this->assertSame('e129f27c-5103-5c5c-844b-cdf0a15e160d', $uuid->toString());
+        self::assertSame('e129f27c-5103-5c5c-844b-cdf0a15e160d', $uuid->toString());
     }
 
     public function testUuid5WithZeroName(): void
     {
         $uuid = Uuid::uuid5(Uuid::NIL, '0');
 
-        $this->assertSame('b6c54489-38a0-5f50-a60a-fd8d76219cae', $uuid->toString());
+        self::assertSame('b6c54489-38a0-5f50-a60a-fd8d76219cae', $uuid->toString());
     }
 
     /**
@@ -1572,7 +1572,7 @@ class UuidTest extends TestCase
     public function testUuidVersionConstantForVersion1(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
-        $this->assertSame($uuid->getVersion(), Uuid::UUID_TYPE_TIME);
+        self::assertSame($uuid->getVersion(), Uuid::UUID_TYPE_TIME);
     }
 
     /**
@@ -1581,7 +1581,7 @@ class UuidTest extends TestCase
     public function testUuidVersionConstantForVersion2(): void
     {
         $uuid = Uuid::fromString('6fa459ea-ee8a-2ca4-894e-db77e160355e');
-        $this->assertSame($uuid->getVersion(), Uuid::UUID_TYPE_DCE_SECURITY);
+        self::assertSame($uuid->getVersion(), Uuid::UUID_TYPE_DCE_SECURITY);
     }
 
     /**
@@ -1590,7 +1590,7 @@ class UuidTest extends TestCase
     public function testUuidVersionConstantForVersion3(): void
     {
         $uuid = Uuid::fromString('6fa459ea-ee8a-3ca4-894e-db77e160355e');
-        $this->assertSame($uuid->getVersion(), Uuid::UUID_TYPE_HASH_MD5);
+        self::assertSame($uuid->getVersion(), Uuid::UUID_TYPE_HASH_MD5);
     }
 
     /**
@@ -1599,7 +1599,7 @@ class UuidTest extends TestCase
     public function testUuidVersionConstantForVersion4(): void
     {
         $uuid = Uuid::fromString('6fabf0bc-603a-42f2-925b-d9f779bd0032');
-        $this->assertSame($uuid->getVersion(), Uuid::UUID_TYPE_RANDOM);
+        self::assertSame($uuid->getVersion(), Uuid::UUID_TYPE_RANDOM);
     }
 
     /**
@@ -1608,13 +1608,13 @@ class UuidTest extends TestCase
     public function testUuidVersionConstantForVersion5(): void
     {
         $uuid = Uuid::fromString('886313e1-3b8a-5372-9b90-0c9aee199e5d');
-        $this->assertSame($uuid->getVersion(), Uuid::UUID_TYPE_HASH_SHA1);
+        self::assertSame($uuid->getVersion(), Uuid::UUID_TYPE_HASH_SHA1);
     }
 
     public function testUuidVersionConstantForVersion6(): void
     {
         $uuid = Uuid::fromString('886313e1-3b8a-6372-9b90-0c9aee199e5d');
-        $this->assertSame($uuid->getVersion(), Uuid::UUID_TYPE_PEABODY);
+        self::assertSame($uuid->getVersion(), Uuid::UUID_TYPE_PEABODY);
     }
 
     public function testGetDateTimeThrowsExceptionWhenDateTimeCannotParseDate(): void
@@ -1653,7 +1653,7 @@ class UuidTest extends TestCase
         string $staticMethod,
         array $args = []
     ): void {
-        $this->assertInstanceOf(LazyUuidFromString::class, Uuid::$staticMethod(...$args));
+        self::assertInstanceOf(LazyUuidFromString::class, Uuid::$staticMethod(...$args));
     }
 
     /**

--- a/tests/Validator/GenericValidatorTest.php
+++ b/tests/Validator/GenericValidatorTest.php
@@ -29,7 +29,7 @@ class GenericValidatorTest extends TestCase
         $validator = new GenericValidator();
 
         foreach ($variations as $variation) {
-            $this->assertSame($expected, $validator->validate($variation));
+            self::assertSame($expected, $validator->validate($variation));
         }
     }
 
@@ -93,6 +93,6 @@ class GenericValidatorTest extends TestCase
 
         $validator = new GenericValidator();
 
-        $this->assertSame($expectedPattern, $validator->getPattern());
+        self::assertSame($expectedPattern, $validator->getPattern());
     }
 }


### PR DESCRIPTION
All methods declared as static are now invoked statically (`::`) instead of dynamically (`->`).

## Description
Static methods should be invoked statically. PHP is quirky in that this behaviour is not enforced, but since this project currently uses a mixture, these have been normalized in the interests of consistency.

## Motivation and context
Besides consistency, invalid invocation style presents a slew of warnings in my editor as pictured. This goes some way towards combating that.

![image](https://user-images.githubusercontent.com/470626/90985846-77617a00-e576-11ea-9fb5-19066cc2b99a.png)

Here's some examples of mixed invocation styles in the current version.

### Static invocation
https://github.com/ramsey/uuid/blob/d103e07a2cb745414992ab3b4a0cd9fa5d783296/tests/UuidTest.php#L1059-L1071

### Dynamic invocation
https://github.com/ramsey/uuid/blob/d103e07a2cb745414992ab3b4a0cd9fa5d783296/tests/UuidTest.php#L1030-L1031

## How has this been tested?
Ran tests locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run-script test` locally, and there were no failures or errors.
