### PR TITLE
Removed redundant interface speficiation

### DIFF
--- a/src/Builder/BuilderCollection.php
+++ b/src/Builder/BuilderCollection.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace Ramsey\Uuid\Builder;
 
 use Ramsey\Collection\AbstractCollection;
-use Ramsey\Collection\CollectionInterface;
 use Ramsey\Uuid\Converter\Number\GenericNumberConverter;
 use Ramsey\Uuid\Converter\Time\GenericTimeConverter;
 use Ramsey\Uuid\Converter\Time\PhpTimeConverter;
@@ -28,7 +27,7 @@ use Traversable;
 /**
  * A collection of UuidBuilderInterface objects
  */
-class BuilderCollection extends AbstractCollection implements CollectionInterface
+class BuilderCollection extends AbstractCollection
 {
     public function getType(): string
     {

--- a/src/Builder/DefaultUuidBuilder.php
+++ b/src/Builder/DefaultUuidBuilder.php
@@ -21,6 +21,6 @@ use Ramsey\Uuid\Rfc4122\UuidBuilder as Rfc4122UuidBuilder;
  *
  * @psalm-immutable
  */
-class DefaultUuidBuilder extends Rfc4122UuidBuilder implements UuidBuilderInterface
+class DefaultUuidBuilder extends Rfc4122UuidBuilder
 {
 }

--- a/src/Guid/Guid.php
+++ b/src/Guid/Guid.php
@@ -18,7 +18,6 @@ use Ramsey\Uuid\Codec\CodecInterface;
 use Ramsey\Uuid\Converter\NumberConverterInterface;
 use Ramsey\Uuid\Converter\TimeConverterInterface;
 use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidInterface;
 
 /**
  * Guid represents a UUID with "native" (little-endian) byte order
@@ -49,7 +48,7 @@ use Ramsey\Uuid\UuidInterface;
  *
  * @psalm-immutable
  */
-final class Guid extends Uuid implements UuidInterface
+final class Guid extends Uuid
 {
     public function __construct(
         Fields $fields,

--- a/src/Nonstandard/Uuid.php
+++ b/src/Nonstandard/Uuid.php
@@ -18,14 +18,13 @@ use Ramsey\Uuid\Codec\CodecInterface;
 use Ramsey\Uuid\Converter\NumberConverterInterface;
 use Ramsey\Uuid\Converter\TimeConverterInterface;
 use Ramsey\Uuid\Uuid as BaseUuid;
-use Ramsey\Uuid\UuidInterface;
 
 /**
  * Nonstandard\Uuid is a UUID that doesn't conform to RFC 4122
  *
  * @psalm-immutable
  */
-final class Uuid extends BaseUuid implements UuidInterface
+final class Uuid extends BaseUuid
 {
     public function __construct(
         Fields $fields,

--- a/src/Provider/Node/NodeProviderCollection.php
+++ b/src/Provider/Node/NodeProviderCollection.php
@@ -15,14 +15,13 @@ declare(strict_types=1);
 namespace Ramsey\Uuid\Provider\Node;
 
 use Ramsey\Collection\AbstractCollection;
-use Ramsey\Collection\CollectionInterface;
 use Ramsey\Uuid\Provider\NodeProviderInterface;
 use Ramsey\Uuid\Type\Hexadecimal;
 
 /**
  * A collection of NodeProviderInterface objects
  */
-class NodeProviderCollection extends AbstractCollection implements CollectionInterface
+class NodeProviderCollection extends AbstractCollection
 {
     public function getType(): string
     {


### PR DESCRIPTION
Several classes implement interfaces already specified by the base class they are extending. Such specifications are redundant and can be safely removed.

## Description
As above.

## Motivation and context
Code cleanup.

## How has this been tested?
Run tests locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run-script test` locally, and there were no failures or errors.
