### PR TITLE
use expectError instead of expectException

### DIFF
--- a/tests/Generator/CombGeneratorTest.php
+++ b/tests/Generator/CombGeneratorTest.php
@@ -127,7 +127,7 @@ class CombGeneratorTest extends TestCase
 
         $generator = new CombGenerator($randomGenerator, $converter);
 
-        $this->expectException(PHPUnitError::class);
+        $this->expectError();
         $generator->generate(7);
     }
 }

--- a/tests/Generator/CombGeneratorTest.php
+++ b/tests/Generator/CombGeneratorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Ramsey\Uuid\Test\Generator;
 
 use Exception;
-use PHPUnit\Framework\Error\Error as PHPUnitError;
 use PHPUnit\Framework\MockObject\MockObject;
 use Ramsey\Uuid\Converter\NumberConverterInterface;
 use Ramsey\Uuid\Exception\InvalidArgumentException;


### PR DESCRIPTION
Using PHPUnit 9

```
1) Ramsey\Uuid\Test\Generator\CombGeneratorTest::testGenerateWithOddNumberOverTimestampBytesCausesError
Support for using expectException() with PHPUnit\Framework\Error\Error is deprecated and will be removed in PHPUnit 10. Use expectError() instead.

```

`expectError` already exists in PHPUnit 8
