### PR TITLE
catch ValueError raised by PHP 8

### DIFF
--- a/src/Generator/DefaultNameGenerator.php
+++ b/src/Generator/DefaultNameGenerator.php
@@ -29,7 +29,11 @@ class DefaultNameGenerator implements NameGeneratorInterface
     public function generate(UuidInterface $ns, string $name, string $hashAlgorithm): string
     {
         /** @var string|bool $bytes */
-        $bytes = @hash($hashAlgorithm, $ns->getBytes() . $name, true);
+        try {
+            $bytes = @hash($hashAlgorithm, $ns->getBytes() . $name, true);
+        } catch (\ValueError $e) {
+            $bytes = false; // keep same behavior than PHP 7 */
+        }
 
         if ($bytes === false) {
             throw new NameException(sprintf(

--- a/src/Generator/DefaultNameGenerator.php
+++ b/src/Generator/DefaultNameGenerator.php
@@ -28,11 +28,11 @@ class DefaultNameGenerator implements NameGeneratorInterface
     /** @psalm-pure */
     public function generate(UuidInterface $ns, string $name, string $hashAlgorithm): string
     {
-        /** @var string|bool $bytes */
         try {
+            /** @var string|bool $bytes */
             $bytes = @hash($hashAlgorithm, $ns->getBytes() . $name, true);
         } catch (\ValueError $e) {
-            $bytes = false; // keep same behavior than PHP 7 */
+            $bytes = false; // keep same behavior than PHP 7
         }
 
         if ($bytes === false) {


### PR DESCRIPTION
Using PHPUnit  9 and PHP 8.0.0RC3

There was 1 failure:
```

1) Ramsey\Uuid\Test\Generator\DefaultNameGeneratorTest::testGenerateThrowsException
Failed asserting that exception of type "ValueError" matches expected exception "Ramsey\Uuid\Exception\NameException". Message was: "hash(): Argument #1 ($algo) must be a valid hashing algorithm" at
/dev/shm/BUILDROOT/php-ramsey-uuid-4.1.1-1.fc31.remi.x86_64/usr/share/php/Ramsey/Uuid/Generator/DefaultNameGenerator.php:33
/dev/shm/BUILD/uuid-cd4032040a750077205918c86049aa0f43d22947/tests/Generator/DefaultNameGeneratorTest.php:78

```