### PR TITLE
Allow install of paragonie/random_compat 9.99.100

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^5.4 | ^7 | ^8",
         "ext-json": "*",
-        "paragonie/random_compat": "^1 | ^2 | 9.99.99",
+        "paragonie/random_compat": "^1 | ^2 | ^9.99.99",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {


### PR DESCRIPTION
## Description
Allow installation of `paragonie/random_compat` version 9.99.100 to avoid downgrades to version 2.x when upgrading a project to PHP 8.

## Motivation and context
`paragonie/random_compat` 9.99.99 is not compatible with PHP 8, but 9.99.100 is, see [`v9.99.99...v9.99.100`#diff-d2ab9925ca](https://github.com/paragonie/random_compat/compare/v9.99.99...v9.99.100#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34)

## How has this been tested?
`composer require 'ramsey/uuid:^3.8'` with PHP 8 installs `paragonie/random_compat` in the wrong version (`2.0.19` instead of `9.99.99`)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have run `composer run-script test` locally, and there were no failures or errors.
