### PR TITLE
Serialization should not use internal codec

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -285,7 +285,7 @@ class Uuid implements UuidInterface
      */
     public function serialize(): string
     {
-        return $this->getBytes();
+        return $this->getFields()->getBytes();
     }
 
     /**

--- a/tests/Codec/OrderedTimeCodecTest.php
+++ b/tests/Codec/OrderedTimeCodecTest.php
@@ -20,12 +20,15 @@ use Ramsey\Uuid\Nonstandard\Fields as NonstandardFields;
 use Ramsey\Uuid\Nonstandard\UuidBuilder;
 use Ramsey\Uuid\Rfc4122\Fields;
 use Ramsey\Uuid\Test\TestCase;
+use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use Ramsey\Uuid\UuidInterface;
 
 use function hex2bin;
 use function pack;
+use function serialize;
 use function str_replace;
+use function unserialize;
 
 class OrderedTimeCodecTest extends TestCase
 {
@@ -228,5 +231,21 @@ class OrderedTimeCodecTest extends TestCase
         );
 
         $codec->decodeBytes($bytes);
+    }
+
+    public function testSerializationDoesNotUseOrderedTimeCodec(): void
+    {
+        $expected = '9ec692cc-67c8-11eb-ae93-0242ac130002';
+
+        $codec = new OrderedTimeCodec(
+            (new UuidFactory())->getUuidBuilder()
+        );
+        $decoded = $codec->decode($expected);
+        $serialized = serialize($decoded);
+        $unserializedUuid = unserialize($serialized);
+
+        $expectedUuid = Uuid::fromString($expected);
+        $this->assertSame($expectedUuid->getVersion(), $unserializedUuid->getVersion());
+        $this->assertTrue($expectedUuid->equals($unserializedUuid));
     }
 }


### PR DESCRIPTION
The change in https://github.com/ramsey/uuid/issues/318 is the root cause of issues https://github.com/ramsey/uuid/issues/329 and https://github.com/ramsey/uuid-doctrine/issues/152. This PR should fix that.

## Description
The  problem is, that call to `getBytes` and subsequently `this->codec->encodeBytes` returns invalid result when UUID is used with `OrderedTimeCodec`. When this combination is used, current master returns binary string with shuffled values (as OrderedTimeCodec does) and deserialization later returns invalid instance of UUID. Then new code is same as would `StringCodec` do.

## Motivation and context
Fixed https://github.com/ramsey/uuid/issues/329 and https://github.com/ramsey/uuid-doctrine/issues/152

## How has this been tested?
Unit test included

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](https://github.com/ramsey/uuid/blob/master/.github/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run-script test` locally, and there were no failures or errors. (I have, some fail, but unrelated to the issue)
