### PR TITLE
Fix soft BC break with `Uuid::fromString()` signature

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -24,6 +24,7 @@ use Ramsey\Uuid\Rfc4122\FieldsInterface as Rfc4122FieldsInterface;
 use Ramsey\Uuid\Type\Hexadecimal;
 use Ramsey\Uuid\Type\Integer as IntegerObject;
 
+use function assert;
 use function bin2hex;
 use function preg_match;
 use function str_replace;
@@ -436,7 +437,7 @@ class Uuid implements UuidInterface
     /**
      * Creates a UUID from the string standard representation
      *
-     * @param non-empty-string $uuid A hexadecimal string
+     * @param string $uuid A hexadecimal string
      *
      * @return UuidInterface A UuidInterface instance created from a hexadecimal
      *     string representation
@@ -452,6 +453,8 @@ class Uuid implements UuidInterface
     public static function fromString(string $uuid): UuidInterface
     {
         if (! self::$factoryReplaced && preg_match(LazyUuidFromString::VALID_REGEX, $uuid) === 1) {
+            assert($uuid !== '');
+
             return new LazyUuidFromString(strtolower($uuid));
         }
 

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -124,6 +124,14 @@ class UuidTest extends TestCase
         $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
     }
 
+    public function testFromStringWithEmptyString(): void
+    {
+        $this->expectException(InvalidUuidStringException::class);
+        $this->expectExceptionMessage('Invalid UUID string: ');
+
+        Uuid::fromString('');
+    }
+
     public function testGetBytes(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');


### PR DESCRIPTION
The `$uuid` parameter on `Uuid::fromString()` [was changed from `string` to `non-empty-string`](https://github.com/ramsey/uuid/commit/c005f69d6e5c16a807093d693ed1dbdf730b3c67#diff-898c45cfd882f04a4877c82e14ce28181f8ea6062654772bfb9fc474014bd6a0R439) this breaks BC for people using static analysis in their downstream projects.

## Description

I've reverted the change to the docblock and used an assertion to teach static analysis tools when the `$uuid` variable is a non empty string instead.

## Motivation and context

Whilst this isn't a language level backwards compatibility break, it does break when consumers are using static analysis tools on their own code base because they'd need to add checks to test if the input is non empty before calling `Uuid::fromString()`.

## How has this been tested?

I've added a unit test covering the call to `Uuid::fromString('')`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
