### PR TITLE
Add support for PHP 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,7 +66,9 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
-          - "8.1"
+        include:
+          - php-version: "8.1"
+            composer-options: "--ignore-platform-req=php"
 
     steps:
       - name: "Checkout repository"
@@ -89,6 +91,14 @@ jobs:
   code-coverage:
     name: "Code coverage"
     runs-on: "ubuntu-latest"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "7.2"
+          - "8.0"
+
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v2"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,6 +66,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
 
     steps:
       - name: "Checkout repository"
@@ -114,7 +115,6 @@ jobs:
   unit-tests:
     name: "Unit Tests"
     runs-on: "ubuntu-latest"
-    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       fail-fast: false
@@ -124,11 +124,8 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
-        experimental:
-          - false
         include:
           - php-version: "8.1"
-            experimental: true
             composer-options: "--ignore-platform-req=php"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "ext-json": "*",
         "brick/math": "^0.8 || ^0.9",
         "ramsey/collection": "^1.0",
-        "symfony/polyfill-ctype": "^1.8"
+        "symfony/polyfill-ctype": "^1.8",
+        "symfony/polyfill-php80": "^1.14"
     },
     "replace": {
         "rhumsaa/uuid": "self.version"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,3 +29,7 @@ parameters:
             message: '#^Call to an undefined method Ramsey\\Uuid\\Fields\\FieldsInterface::get.*$#'
             count: 9
             path: ./src/Lazy/LazyUuidFromString.php
+        -
+            message: '#^Result of \|\| is always false\.$#'
+            count: 1
+            path: ./src/Type/Time.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.18.2@19aa905f7c3c7350569999a93c40ae91ae4e1626">
+<files psalm-version="4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa">
   <file src="src/Builder/DegradedUuidBuilder.php">
     <DeprecatedClass occurrences="3">
       <code>DegradedUuid</code>
@@ -48,6 +48,11 @@
       <code>$timeProvider</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="src/Fields/SerializableFieldsTrait.php">
+    <UnusedMethodCall occurrences="1">
+      <code>unserialize</code>
+    </UnusedMethodCall>
+  </file>
   <file src="src/Generator/PeclUuidNameGenerator.php">
     <ImpureFunctionCall occurrences="3">
       <code>uuid_generate_md5</code>
@@ -61,6 +66,11 @@
       <code>$this</code>
       <code>$this</code>
     </ImpureVariable>
+  </file>
+  <file src="src/Lazy/LazyUuidFromString.php">
+    <UnusedMethodCall occurrences="1">
+      <code>unserialize</code>
+    </UnusedMethodCall>
   </file>
   <file src="src/Nonstandard/UuidBuilder.php">
     <ImpureVariable occurrences="3">
@@ -108,6 +118,26 @@
       <code>$this</code>
     </ImpureVariable>
   </file>
+  <file src="src/Type/Decimal.php">
+    <UnusedMethodCall occurrences="1">
+      <code>unserialize</code>
+    </UnusedMethodCall>
+  </file>
+  <file src="src/Type/Hexadecimal.php">
+    <UnusedMethodCall occurrences="1">
+      <code>unserialize</code>
+    </UnusedMethodCall>
+  </file>
+  <file src="src/Type/Integer.php">
+    <UnusedMethodCall occurrences="1">
+      <code>unserialize</code>
+    </UnusedMethodCall>
+  </file>
+  <file src="src/Type/Time.php">
+    <UnusedMethodCall occurrences="1">
+      <code>__construct</code>
+    </UnusedMethodCall>
+  </file>
   <file src="src/Uuid.php">
     <ImpureMethodCall occurrences="6">
       <code>getFactory</code>
@@ -117,6 +147,9 @@
       <code>getFactory</code>
       <code>getFactory</code>
     </ImpureMethodCall>
+    <UnusedMethodCall occurrences="1">
+      <code>unserialize</code>
+    </UnusedMethodCall>
   </file>
   <file src="src/UuidFactory.php">
     <ImpurePropertyFetch occurrences="7">

--- a/src/Fields/SerializableFieldsTrait.php
+++ b/src/Fields/SerializableFieldsTrait.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 
 namespace Ramsey\Uuid\Fields;
 
+use ValueError;
+
 use function base64_decode;
+use function sprintf;
 use function strlen;
 
 /**
@@ -43,6 +46,14 @@ trait SerializableFieldsTrait
     }
 
     /**
+     * @return array{bytes: string}
+     */
+    public function __serialize(): array
+    {
+        return ['bytes' => $this->getBytes()];
+    }
+
+    /**
      * Constructs the object from a serialized string representation
      *
      * @param string $serialized The serialized string representation of the object
@@ -57,5 +68,17 @@ trait SerializableFieldsTrait
         } else {
             $this->__construct(base64_decode($serialized));
         }
+    }
+
+    /**
+     * @param array{bytes: string} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        if (!isset($data['bytes'])) {
+            throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
+        }
+
+        $this->unserialize($data['bytes']);
     }
 }

--- a/src/Fields/SerializableFieldsTrait.php
+++ b/src/Fields/SerializableFieldsTrait.php
@@ -75,9 +75,11 @@ trait SerializableFieldsTrait
      */
     public function __unserialize(array $data): void
     {
+        // @codeCoverageIgnoreStart
         if (!isset($data['bytes'])) {
             throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
         }
+        // @codeCoverageIgnoreEnd
 
         $this->unserialize($data['bytes']);
     }

--- a/src/Lazy/LazyUuidFromString.php
+++ b/src/Lazy/LazyUuidFromString.php
@@ -24,10 +24,12 @@ use Ramsey\Uuid\Type\Hexadecimal;
 use Ramsey\Uuid\Type\Integer as IntegerObject;
 use Ramsey\Uuid\UuidFactory;
 use Ramsey\Uuid\UuidInterface;
+use ValueError;
 
 use function assert;
 use function bin2hex;
 use function hex2bin;
+use function sprintf;
 use function str_replace;
 use function substr;
 
@@ -91,6 +93,16 @@ final class LazyUuidFromString implements UuidInterface
     }
 
     /**
+     * @return array{string: string}
+     *
+     * @psalm-return array{string: non-empty-string}
+     */
+    public function __serialize(): array
+    {
+        return ['string' => $this->uuid];
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @param string $serialized
@@ -100,6 +112,20 @@ final class LazyUuidFromString implements UuidInterface
     public function unserialize($serialized): void
     {
         $this->uuid = $serialized;
+    }
+
+    /**
+     * @param array{string: string} $data
+     *
+     * @psalm-param array{string: non-empty-string} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        if (!isset($data['string'])) {
+            throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
+        }
+
+        $this->unserialize($data['string']);
     }
 
     /** @psalm-suppress DeprecatedMethod */

--- a/src/Lazy/LazyUuidFromString.php
+++ b/src/Lazy/LazyUuidFromString.php
@@ -121,9 +121,11 @@ final class LazyUuidFromString implements UuidInterface
      */
     public function __unserialize(array $data): void
     {
+        // @codeCoverageIgnoreStart
         if (!isset($data['string'])) {
             throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
         }
+        // @codeCoverageIgnoreEnd
 
         $this->unserialize($data['string']);
     }

--- a/src/Type/Decimal.php
+++ b/src/Type/Decimal.php
@@ -126,9 +126,11 @@ final class Decimal implements NumberInterface
      */
     public function __unserialize(array $data): void
     {
+        // @codeCoverageIgnoreStart
         if (!isset($data['string'])) {
             throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
         }
+        // @codeCoverageIgnoreEnd
 
         $this->unserialize($data['string']);
     }

--- a/src/Type/Decimal.php
+++ b/src/Type/Decimal.php
@@ -15,8 +15,10 @@ declare(strict_types=1);
 namespace Ramsey\Uuid\Type;
 
 use Ramsey\Uuid\Exception\InvalidArgumentException;
+use ValueError;
 
 use function is_numeric;
+use function sprintf;
 
 /**
  * A value object representing a decimal
@@ -99,6 +101,14 @@ final class Decimal implements NumberInterface
     }
 
     /**
+     * @return array{string: string}
+     */
+    public function __serialize(): array
+    {
+        return ['string' => $this->toString()];
+    }
+
+    /**
      * Constructs the object from a serialized string representation
      *
      * @param string $serialized The serialized string representation of the object
@@ -109,5 +119,17 @@ final class Decimal implements NumberInterface
     public function unserialize($serialized): void
     {
         $this->__construct($serialized);
+    }
+
+    /**
+     * @param array{string: string} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        if (!isset($data['string'])) {
+            throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
+        }
+
+        $this->unserialize($data['string']);
     }
 }

--- a/src/Type/Hexadecimal.php
+++ b/src/Type/Hexadecimal.php
@@ -105,9 +105,11 @@ final class Hexadecimal implements TypeInterface
      */
     public function __unserialize(array $data): void
     {
+        // @codeCoverageIgnoreStart
         if (!isset($data['string'])) {
             throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
         }
+        // @codeCoverageIgnoreEnd
 
         $this->unserialize($data['string']);
     }

--- a/src/Type/Hexadecimal.php
+++ b/src/Type/Hexadecimal.php
@@ -15,8 +15,10 @@ declare(strict_types=1);
 namespace Ramsey\Uuid\Type;
 
 use Ramsey\Uuid\Exception\InvalidArgumentException;
+use ValueError;
 
 use function ctype_xdigit;
+use function sprintf;
 use function strpos;
 use function strtolower;
 use function substr;
@@ -78,6 +80,14 @@ final class Hexadecimal implements TypeInterface
     }
 
     /**
+     * @return array{string: string}
+     */
+    public function __serialize(): array
+    {
+        return ['string' => $this->toString()];
+    }
+
+    /**
      * Constructs the object from a serialized string representation
      *
      * @param string $serialized The serialized string representation of the object
@@ -88,5 +98,17 @@ final class Hexadecimal implements TypeInterface
     public function unserialize($serialized): void
     {
         $this->__construct($serialized);
+    }
+
+    /**
+     * @param array{string: string} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        if (!isset($data['string'])) {
+            throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
+        }
+
+        $this->unserialize($data['string']);
     }
 }

--- a/src/Type/Integer.php
+++ b/src/Type/Integer.php
@@ -15,9 +15,11 @@ declare(strict_types=1);
 namespace Ramsey\Uuid\Type;
 
 use Ramsey\Uuid\Exception\InvalidArgumentException;
+use ValueError;
 
 use function ctype_digit;
 use function ltrim;
+use function sprintf;
 use function strpos;
 use function substr;
 
@@ -115,6 +117,14 @@ final class Integer implements NumberInterface
     }
 
     /**
+     * @return array{string: string}
+     */
+    public function __serialize(): array
+    {
+        return ['string' => $this->toString()];
+    }
+
+    /**
      * Constructs the object from a serialized string representation
      *
      * @param string $serialized The serialized string representation of the object
@@ -125,5 +135,17 @@ final class Integer implements NumberInterface
     public function unserialize($serialized): void
     {
         $this->__construct($serialized);
+    }
+
+    /**
+     * @param array{string: string} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        if (!isset($data['string'])) {
+            throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
+        }
+
+        $this->unserialize($data['string']);
     }
 }

--- a/src/Type/Integer.php
+++ b/src/Type/Integer.php
@@ -142,9 +142,11 @@ final class Integer implements NumberInterface
      */
     public function __unserialize(array $data): void
     {
+        // @codeCoverageIgnoreStart
         if (!isset($data['string'])) {
             throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
         }
+        // @codeCoverageIgnoreEnd
 
         $this->unserialize($data['string']);
     }

--- a/src/Type/Time.php
+++ b/src/Type/Time.php
@@ -16,10 +16,12 @@ namespace Ramsey\Uuid\Type;
 
 use Ramsey\Uuid\Exception\UnsupportedOperationException;
 use Ramsey\Uuid\Type\Integer as IntegerObject;
+use ValueError;
 use stdClass;
 
 use function json_decode;
 use function json_encode;
+use function sprintf;
 
 /**
  * A value object representing a timestamp
@@ -89,6 +91,17 @@ final class Time implements TypeInterface
     }
 
     /**
+     * @return array{seconds: string, microseconds: string}
+     */
+    public function __serialize(): array
+    {
+        return [
+            'seconds' => $this->getSeconds()->toString(),
+            'microseconds' => $this->getMicroseconds()->toString(),
+        ];
+    }
+
+    /**
      * Constructs the object from a serialized string representation
      *
      * @param string $serialized The serialized string representation of the object
@@ -108,5 +121,17 @@ final class Time implements TypeInterface
         }
 
         $this->__construct($time->seconds, $time->microseconds);
+    }
+
+    /**
+     * @param array{seconds: string, microseconds: string} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        if (!isset($data['seconds']) || !isset($data['microseconds'])) {
+            throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
+        }
+
+        $this->__construct($data['seconds'], $data['microseconds']);
     }
 }

--- a/src/Type/Time.php
+++ b/src/Type/Time.php
@@ -128,9 +128,11 @@ final class Time implements TypeInterface
      */
     public function __unserialize(array $data): void
     {
+        // @codeCoverageIgnoreStart
         if (!isset($data['seconds']) || !isset($data['microseconds'])) {
             throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
         }
+        // @codeCoverageIgnoreEnd
 
         $this->__construct($data['seconds'], $data['microseconds']);
     }

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -23,10 +23,12 @@ use Ramsey\Uuid\Lazy\LazyUuidFromString;
 use Ramsey\Uuid\Rfc4122\FieldsInterface as Rfc4122FieldsInterface;
 use Ramsey\Uuid\Type\Hexadecimal;
 use Ramsey\Uuid\Type\Integer as IntegerObject;
+use ValueError;
 
 use function assert;
 use function bin2hex;
 use function preg_match;
+use function sprintf;
 use function str_replace;
 use function strcmp;
 use function strlen;
@@ -290,6 +292,14 @@ class Uuid implements UuidInterface
     }
 
     /**
+     * @return array{bytes: string}
+     */
+    public function __serialize(): array
+    {
+        return ['bytes' => $this->serialize()];
+    }
+
+    /**
      * Re-constructs the object from its serialized form
      *
      * @param string $serialized The serialized PHP string to unserialize into
@@ -311,6 +321,18 @@ class Uuid implements UuidInterface
         $this->numberConverter = $uuid->numberConverter;
         $this->fields = $uuid->fields;
         $this->timeConverter = $uuid->timeConverter;
+    }
+
+    /**
+     * @param array{bytes: string} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        if (!isset($data['bytes'])) {
+            throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
+        }
+
+        $this->unserialize($data['bytes']);
     }
 
     public function compareTo(UuidInterface $other): int

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -328,9 +328,11 @@ class Uuid implements UuidInterface
      */
     public function __unserialize(array $data): void
     {
+        // @codeCoverageIgnoreStart
         if (!isset($data['bytes'])) {
             throw new ValueError(sprintf('%s(): Argument #1 ($data) is invalid', __METHOD__));
         }
+        // @codeCoverageIgnoreEnd
 
         $this->unserialize($data['bytes']);
     }


### PR DESCRIPTION
This PR gets this library working on PHP 8.1. The new PHP 7.4 style serialisation is now mandatory, from PHP 8.1 onwards. I've checked that the two incompatible serialisation formats are in fact compatible. The old style can be deserialized just fine: https://3v4l.org/XfUS3. This means upgrading is easy and no risk. On PHP 7.2 and 7.3, there are no changes. On PHP 7.4+, the old style gets deserialized properly, and going forward, the new style will be used for serialisation.