### PR TITLE
Fix phpunit deprecation warning

### DIFF
--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -91,7 +91,7 @@ class SystemNodeProviderTest extends TestCase
             'Node should be a hexadecimal string of 12 characters. Actual node: %s (length: %s)',
             [$node->toString(), strlen($node->toString()),]
         );
-        $this->assertRegExp('/^[A-Fa-f0-9]{12}$/', $node->toString(), $message);
+        $this->assertMatchesRegularExpression('/^[A-Fa-f0-9]{12}$/', $node->toString(), $message);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
PHPUnit currently spits out warning about the usage of a deprecated function, I refactored the code to use the suggested replacement.
## Description
<!--- Describe your changes in detail. -->
When running the test suite phpunit spits out the following warning
```bash
assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.
```
I replaced the usage of `assertRegExp` with `assertMatchesRegularExpression`.
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It removes the usage of currently deprecated code.
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The testcase that has been updated still passes.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
