### PR TITLE
LazyUuidFromString for valid UUIDs in uppercase

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -476,10 +476,11 @@ class Uuid implements UuidInterface
      */
     public static function fromString(string $uuid): UuidInterface
     {
+        $uuid = strtolower($uuid);
         if (! self::$factoryReplaced && preg_match(LazyUuidFromString::VALID_REGEX, $uuid) === 1) {
             assert($uuid !== '');
 
-            return new LazyUuidFromString(strtolower($uuid));
+            return new LazyUuidFromString($uuid);
         }
 
         return self::getFactory()->fromString($uuid);

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -132,6 +132,17 @@ class UuidTest extends TestCase
         Uuid::fromString('');
     }
 
+    public function testFromStringUppercase(): void
+    {
+        $uuid = Uuid::fromString('FF6F8CB0-C57D-11E1-9B21-0800200C9A66');
+        $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
+    }
+
+    public function testFromStringLazyUuidFromUppercase(): void
+    {
+        $this->assertInstanceOf(LazyUuidFromString::class, Uuid::fromString('FF6F8CB0-C57D-11E1-9B21-0800200C9A66'));
+    }
+
     public function testGetBytes(): void
     {
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');


### PR DESCRIPTION
This pull request tries to improve the Uuid::fromString static class by creating LazyUuidFromString even for UUID string which are not lowercase.

## Description
This pull request solves discrepancy of returning LazyUuidFromString for UUIDs, which are not in lower case. LazyUuidFromString::VALID_REGEX is case sensitive, so only UUID strings in lower case are accepted. In the same time, the function strtolower() is called in constructor parameter, but the if statement already accepted only strings in lowercase. Thus calling the strtolower on string in lowercase is redundant.
I updated the method so it lowers the string first and then tries to match the regexp. If it is valid uuid string according to the regexp, then instance of LazyUuidFromString is returned. Otherwise the functionality is not affected.

## Motivation and context
When reading data from MS SQL, their GUID strings are returned in uppercase. Calling Uuid::fromString creates for example UuidV4 instance, but most of the time, the LazyUuidFromString object would be sufficient (there is no need for parsing the UUID) (specially when UuidInterface is used for methods typehinting).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
