### PR TITLE
Feature/assert non empty string

### DIFF
--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -26,3 +26,7 @@ parameters:
                 - ./tests/Guid/*Test.php
                 - ./tests/Nonstandard/*Test.php
                 - ./tests/Rfc4122/*Test.php
+        -
+            message: "#^Method Ramsey\\\\Uuid\\\\.+ should return non-empty-string but returns string\\.$#"
+            paths:
+                - ./tests/static-analysis/ValidUuidIsNonEmpty.php

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -537,6 +537,8 @@ class Uuid implements UuidInterface
      *
      * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
      *             but under constant factory setups, this method operates in functionally pure manners
+     *
+     * @psalm-assert-if-true non-empty-string $uuid
      */
     public static function isValid(string $uuid): bool
     {

--- a/tests/static-analysis/ValidUuidIsNonEmpty.php
+++ b/tests/static-analysis/ValidUuidIsNonEmpty.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ramsey\Uuid\StaticAnalysis;
+
+use InvalidArgumentException;
+use Ramsey\Uuid\Uuid;
+
+final class ValidUuidIsNonEmpty
+{
+    /** @return non-empty-string */
+    public function validUuidsAreNotEmpty(string $input): string
+    {
+        if (Uuid::isValid($input)) {
+            return $input;
+        }
+
+        throw new InvalidArgumentException('Not a UUID');
+    }
+}

--- a/tests/static-analysis/ValidUuidIsNonEmpty.php
+++ b/tests/static-analysis/ValidUuidIsNonEmpty.php
@@ -18,4 +18,18 @@ final class ValidUuidIsNonEmpty
 
         throw new InvalidArgumentException('Not a UUID');
     }
+
+    /**
+     * @param non-empty-string $input
+     *
+     * @return non-empty-string
+     */
+    public function givenNonEmptyInputAssertionRemainsValid(string $input): string
+    {
+        if (Uuid::isValid($input)) {
+            return $input;
+        }
+
+        throw new InvalidArgumentException('Not a UUID');
+    }
 }


### PR DESCRIPTION
## Description

Adds a psalm assertion to `Uuid::isValid()` to assert the input is also a non-empty-string when validation passes.

## Motivation and context

Improves static analysis for consumers

## How has this been tested?

Added code to `tests/static-analysis/ValidUuidIsNonEmpty.php` that fails psalm checks without the assertion.

I don't know how to get PHPStan to accept the test returns a non-empty-string type - I'm unfamiliar with PHPStan and it doesn't seem to support Psalm's assert-if-true annotation??

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
