### PR TITLE
Allow brick/math 0.10.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0",
         "ext-ctype": "*",
         "ext-json": "*",
-        "brick/math": "^0.8 || ^0.9",
+        "brick/math": "^0.8 || ^0.9 || ^0.10",
         "ramsey/collection": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

Allows the 0.10.x series of `brick/math` too. In the v5 branch, we can probably drop 0.8.x and 0.9.x.

## Motivation and context

`composer outdated` detected this outdated peer dependency. As far as I can tell, upgrading is straightfoward.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
