### PR TITLE
SystemNodeProvider: Dismiss zero'd mac address

### DIFF
--- a/src/Provider/Node/SystemNodeProvider.php
+++ b/src/Provider/Node/SystemNodeProvider.php
@@ -135,7 +135,11 @@ class SystemNodeProvider implements NodeProviderInterface
 
         $node = '';
         if (preg_match_all(self::IFCONFIG_PATTERN, $ifconfig, $matches, PREG_PATTERN_ORDER)) {
-            $node = $matches[1][0] ?? '';
+            foreach ($matches[1] as $iface) {
+                if ($iface !== '00-00-00-00-00-00') {
+                    $node = $iface;
+                }
+            }
         }
 
         return $node;

--- a/src/Provider/Node/SystemNodeProvider.php
+++ b/src/Provider/Node/SystemNodeProvider.php
@@ -133,16 +133,15 @@ class SystemNodeProvider implements NodeProviderInterface
 
         $ifconfig = (string) ob_get_clean();
 
-        $node = '';
         if (preg_match_all(self::IFCONFIG_PATTERN, $ifconfig, $matches, PREG_PATTERN_ORDER)) {
             foreach ($matches[1] as $iface) {
-                if ($iface !== '00-00-00-00-00-00') {
-                    $node = $iface;
+                if ($iface !== '00:00:00:00:00:00' && $iface !== '00-00-00-00-00-00') {
+                    return $iface;
                 }
             }
         }
 
-        return $node;
+        return '';
     }
 
     /**

--- a/tests/Provider/Node/SystemNodeProviderTest.php
+++ b/tests/Provider/Node/SystemNodeProviderTest.php
@@ -722,6 +722,7 @@ class SystemNodeProviderTest extends TestCase
             'Without leading whitespace' => ['AA-BB-CC-DD-EE-FF '],
             'Without trailing linebreak' => ["\nAA-BB-CC-DD-EE-FF"],
             'Without trailing whitespace' => [' AA-BB-CC-DD-EE-FF'],
+            'All zero MAC address' => ['00-00-00-00-00-00'],
         ];
     }
 
@@ -741,6 +742,7 @@ class SystemNodeProviderTest extends TestCase
             ['01-23-45:67:89:ab'],
             ['01-23-45-67:89:ab'],
             ['01-23-45-67-89:ab'],
+            ['00:00:00:00:00:00'],
         ];
     }
 
@@ -808,6 +810,10 @@ TXT
                 EHC29: flags=0<> mtu 0
                 XHC20: flags=0<> mtu 0
                 EHC26: flags=0<> mtu 0
+                aa0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+                    options=10b<RXCSUM,TXCSUM,VLAN_HWTAGGING,AV>
+                    ether 00:00:00:00:00:00
+                    status: active
                 en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
                     options=10b<RXCSUM,TXCSUM,VLAN_HWTAGGING,AV>
                     ether 10:dd:b1:b4:e4:8e
@@ -874,6 +880,12 @@ TXT
                    WINS Proxy Enabled. . . . . . . . : No
                    DNS Suffix Search List. . . . . . : network.lan
 
+                Some kind of adapter:
+
+                   Connection-specific DNS Suffix  . : network.foo
+                   Description . . . . . . . . . . . : Some Adapter
+                   Physical Address. . . . . . . . . : 00-00-00-00-00-00
+
                 Ethernet adapter Ethernet:
 
                    Connection-specific DNS Suffix  . : network.lan
@@ -906,6 +918,7 @@ TXT
             ],
             'Full output - FreeBSD' => [<<<'TXT'
                 Name    Mtu Network       Address              Ipkts Ierrs Idrop    Opkts Oerrs  Coll
+                aa0       0 <Link#0>      00:00:00:00:00:00        0     0     0        0     0     0
                 em0    1500 <Link#1>      08:00:27:71:a1:00    65514     0     0    42918     0     0
                 em1    1500 <Link#2>      08:00:27:d0:60:a0     1199     0     0      535     0     0
                 lo0   16384 <Link#3>      lo0                      4     0     0        4     0     0
@@ -930,7 +943,6 @@ TXT
             'FF:FF:FF:FF:FF:FF' => ["\nFF:FF:FF:FF:FF:FF\n", 'ffffffffffff'],
 
             /* Incorrect variations that are also accepted */
-            'Local host' => ["\n00:00:00:00:00:00\n", '000000000000'],
             'Too long -- extra character' => ["\nABC-01-23-45-67-89\n", 'bc0123456789'],
             'Too long -- extra tuple' => ["\n01-AA-BB-CC-DD-EE-FF\n", '01aabbccddee'],
         ];


### PR DESCRIPTION
Dismiss zero'd mac addresses while generating a node.

## Description
This PR adds a foreach and cycles through the fetched interfaces, until a usable one is found. If there is no match, it will keep generating a new random node.

## Motivation and context
The vpn interface on the server is returning a mac address like '00-00-00-00-00-00' thus having a Node filled with zeros. Refs ramsey/uuid-doctrine#186

## How has this been tested?
Comparing the result on the local dev environment (mac) and the production environment (debian). Generate a `$uuid = Uuid::uuid1();` and var_dump the output. To further pinpoint the issue, I've set multiple var_dumps to get to the correct file and method.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.


I haven't worked with tests before, but from the execution logic I guess they shouldn't need adjustment. When executing `composer test` I've got some exceptions in this file (`PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught Exception: Serialization of 'Closure' is not allowed in Standard input code:114`) - but this error is thrown with as well as without my change. As I stated before, I'm not used to tests...