### PR TITLE
fix missing #[ReturnTypeWillChange] in Uuid

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -213,6 +213,7 @@ class Uuid implements UuidInterface
      * @return string
      * @link http://php.net/manual/en/class.jsonserializable.php
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toString();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
When adapting Uuid class to php 8.1, the annotation #[ReturnTypeWillChange] has been added on top of the method provided by the Serialize interface but not the one from JsonSerialize. 

## Motivation and context
this could leed to the following error `PHP Fatal error:  During inheritance of JsonSerializable: Uncaught Error: Class "Ramsey\Uuid\Uuid" not found`

## How has this been tested?
directly by implementing the change in the Class, nor more `PHP Fatal error:  During inheritance of JsonSerializable: Uncaught Error: Class "Ramsey\Uuid\Uuid" not found`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
