### PR TITLE
Bump minimum version of ramsey/collection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0",
         "ext-json": "*",
         "brick/math": "^0.8.8 || ^0.9 || ^0.10",
-        "ramsey/collection": "^1.1.2"
+        "ramsey/collection": "^1.2"
     },
     "require-dev": {
         "captainhook/captainhook": "^5.10",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0",
         "ext-json": "*",
         "brick/math": "^0.8.8 || ^0.9 || ^0.10",
-        "ramsey/collection": "^1.0"
+        "ramsey/collection": "^1.1.2"
     },
     "require-dev": {
         "captainhook/captainhook": "^5.10",


### PR DESCRIPTION
By bumping ramsey/collection to the latest version that supports PHP 8.1, we prevent builds from third party libraries from failing when they install dependencies with `prefer-lowest`. 

## Description
If right now, a library requires `ramsey/uuid` it'll install the lowest version of ramsey/collection of its ^1.0 constraint on PHP 8.1 instead of the actual compatible one of v1.2.0. By bumping the minimum version we make sure it'll install the latest version when a third party tries to test its lowest bounds with `prefer-lowest`. 

## Motivation and context
We'll be able to remove the workaround here: https://github.com/laravel/framework/blob/9.x/.github/workflows/tests.yml#L76

## How has this been tested?
We'll be able to test this once a new version of ramsey/uuid is tagged.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
