### PR TITLE
fix: Amends psalm assertion syntax on `Uuid::isValid()` to prevent incorrect type inference

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -569,7 +569,7 @@ class Uuid implements UuidInterface
      * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
      *             but under constant factory setups, this method operates in functionally pure manners
      *
-     * @psalm-assert-if-true non-empty-string $uuid
+     * @psalm-assert-if-true =non-empty-string $uuid
      */
     public static function isValid(string $uuid): bool
     {

--- a/tests/static-analysis/ValidUuidIsNonEmpty.php
+++ b/tests/static-analysis/ValidUuidIsNonEmpty.php
@@ -32,4 +32,13 @@ final class ValidUuidIsNonEmpty
 
         throw new InvalidArgumentException('Not a UUID');
     }
+
+    public function givenInvalidInputValueRemainsAString(string $input): string
+    {
+        if (Uuid::isValid($input)) {
+            return 'It Worked!';
+        }
+
+        return $input;
+    }
 }


### PR DESCRIPTION
## Description

The reason for this change is described in #478

Closes #478 
