### PR TITLE
Add explicit `Stringable` interface to `UuidInterface`

### DIFF
--- a/src/UuidInterface.php
+++ b/src/UuidInterface.php
@@ -19,6 +19,7 @@ use Ramsey\Uuid\Fields\FieldsInterface;
 use Ramsey\Uuid\Type\Hexadecimal;
 use Ramsey\Uuid\Type\Integer as IntegerObject;
 use Serializable;
+use Stringable;
 
 /**
  * A UUID is a universally unique identifier adhering to an agreed-upon
@@ -29,7 +30,8 @@ use Serializable;
 interface UuidInterface extends
     DeprecatedUuidInterface,
     JsonSerializable,
-    Serializable
+    Serializable,
+    Stringable
 {
     /**
      * Returns -1, 0, or 1 if the UUID is less than, equal to, or greater than

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -41,6 +41,7 @@ use Ramsey\Uuid\UuidFactoryInterface;
 use Ramsey\Uuid\UuidInterface;
 use Ramsey\Uuid\Validator\GenericValidator;
 use Ramsey\Uuid\Validator\ValidatorInterface;
+use Stringable;
 use stdClass;
 
 use function base64_decode;
@@ -575,11 +576,13 @@ class UuidTest extends TestCase
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
         $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
         $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', (string) $uuid);
+        $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', (static fn (Stringable $uuid) => (string) $uuid)($uuid));
 
         // Check with an old date
         $uuid = Uuid::fromString('0901e600-0154-1000-9b21-0800200c9a66');
         $this->assertSame('0901e600-0154-1000-9b21-0800200c9a66', $uuid->toString());
         $this->assertSame('0901e600-0154-1000-9b21-0800200c9a66', (string) $uuid);
+        $this->assertSame('0901e600-0154-1000-9b21-0800200c9a66', (static fn (Stringable $uuid) => (string) $uuid)($uuid));
     }
 
     public function testUuid1(): void

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -576,13 +576,19 @@ class UuidTest extends TestCase
         $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
         $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
         $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', (string) $uuid);
-        $this->assertSame('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', (static fn (Stringable $uuid) => (string) $uuid)($uuid));
+        $this->assertSame(
+            'ff6f8cb0-c57d-11e1-9b21-0800200c9a66',
+            (static fn (Stringable $uuid) => (string) $uuid)($uuid)
+        );
 
         // Check with an old date
         $uuid = Uuid::fromString('0901e600-0154-1000-9b21-0800200c9a66');
         $this->assertSame('0901e600-0154-1000-9b21-0800200c9a66', $uuid->toString());
         $this->assertSame('0901e600-0154-1000-9b21-0800200c9a66', (string) $uuid);
-        $this->assertSame('0901e600-0154-1000-9b21-0800200c9a66', (static fn (Stringable $uuid) => (string) $uuid)($uuid));
+        $this->assertSame(
+            '0901e600-0154-1000-9b21-0800200c9a66',
+            (static fn (Stringable $uuid) => (string) $uuid)($uuid)
+        );
     }
 
     public function testUuid1(): void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Even tho, the `Stringable` interface is implicit on all objects containing the method `__toString`, it is recommended by PHP to explicitly setting that interface.

From php.net documentation:
> [...] Unlike most interfaces, **Stringable** is implicitly present on any class that has the magic `__toString()` method defined, although it can and should be declared explicitly.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I've used `Stringable` notation recently in an upstream project and then realized that the `UuidInterface` does not explicitly implements the interface. Due to the magic PHP provides starting with PHP 8.0, it still implements `Stringable` and thus I was able to use it but to avoid future issues with i.e. PHP 9 where this behavior might change, I wanted to add this here.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've added 2 new checks to the existing tests. 
Please note that these tests won't fail even if we remove the interface again due to the fact that PHP adds it implicitly whenever a `__toString` method is available.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have added tests to cover my changes.
