### PR TITLE
Fix Unserialize error with OrderedTimeCodec #494

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -293,7 +293,7 @@ class Uuid implements UuidInterface
      */
     public function serialize(): string
     {
-        return $this->getFields()->getBytes();
+        return $this->codec->encode($this);
     }
 
     /**
@@ -446,20 +446,20 @@ class Uuid implements UuidInterface
      */
     public static function fromBytes(string $bytes): UuidInterface
     {
-        if (! self::$factoryReplaced && strlen($bytes) === 16) {
+        if (!self::$factoryReplaced && strlen($bytes) === 16) {
             $base16Uuid = bin2hex($bytes);
 
             // Note: we are calling `fromString` internally because we don't know if the given `$bytes` is a valid UUID
             return self::fromString(
                 substr($base16Uuid, 0, 8)
-                . '-'
-                . substr($base16Uuid, 8, 4)
-                . '-'
-                . substr($base16Uuid, 12, 4)
-                . '-'
-                . substr($base16Uuid, 16, 4)
-                . '-'
-                . substr($base16Uuid, 20, 12)
+                    . '-'
+                    . substr($base16Uuid, 8, 4)
+                    . '-'
+                    . substr($base16Uuid, 12, 4)
+                    . '-'
+                    . substr($base16Uuid, 16, 4)
+                    . '-'
+                    . substr($base16Uuid, 20, 12)
             );
         }
 
@@ -485,7 +485,7 @@ class Uuid implements UuidInterface
     public static function fromString(string $uuid): UuidInterface
     {
         $uuid = strtolower($uuid);
-        if (! self::$factoryReplaced && preg_match(LazyUuidFromString::VALID_REGEX, $uuid) === 1) {
+        if (!self::$factoryReplaced && preg_match(LazyUuidFromString::VALID_REGEX, $uuid) === 1) {
             assert($uuid !== '');
 
             return new LazyUuidFromString($uuid);

--- a/tests/ExpectedBehaviorTest.php
+++ b/tests/ExpectedBehaviorTest.php
@@ -5,6 +5,7 @@ namespace Ramsey\Uuid\Test;
 use Brick\Math\BigInteger;
 use Ramsey\Uuid\Builder\DegradedUuidBuilder;
 use Ramsey\Uuid\Codec\CodecInterface;
+use Ramsey\Uuid\Codec\OrderedTimeCodec;
 use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Converter\Number\DegradedNumberConverter;
 use Ramsey\Uuid\Converter\Time\DegradedTimeConverter;
@@ -74,21 +75,21 @@ class ExpectedBehaviorTest extends TestCase
         $this->assertSame(
             (string) $uuid->getHex(),
             $uuid->getTimeLowHex()
-            . $uuid->getTimeMidHex()
-            . $uuid->getTimeHiAndVersionHex()
-            . $uuid->getClockSeqHiAndReservedHex()
-            . $uuid->getClockSeqLowHex()
-            . $uuid->getNodeHex()
+                . $uuid->getTimeMidHex()
+                . $uuid->getTimeHiAndVersionHex()
+                . $uuid->getClockSeqHiAndReservedHex()
+                . $uuid->getClockSeqLowHex()
+                . $uuid->getNodeHex()
         );
 
         $this->assertSame(
             (string) $uuid->getHex(),
             $uuid->getFieldsHex()['time_low']
-            . $uuid->getFieldsHex()['time_mid']
-            . $uuid->getFieldsHex()['time_hi_and_version']
-            . $uuid->getFieldsHex()['clock_seq_hi_and_reserved']
-            . $uuid->getFieldsHex()['clock_seq_low']
-            . $uuid->getFieldsHex()['node']
+                . $uuid->getFieldsHex()['time_mid']
+                . $uuid->getFieldsHex()['time_hi_and_version']
+                . $uuid->getFieldsHex()['clock_seq_hi_and_reserved']
+                . $uuid->getFieldsHex()['clock_seq_low']
+                . $uuid->getFieldsHex()['node']
         );
 
         $this->assertIsString($uuid->getUrn());
@@ -100,21 +101,21 @@ class ExpectedBehaviorTest extends TestCase
         $this->assertSame(
             $uuid->toString(),
             $uuid->getTimeLowHex() . '-'
-            . $uuid->getTimeMidHex() . '-'
-            . $uuid->getTimeHiAndVersionHex() . '-'
-            . $uuid->getClockSeqHiAndReservedHex()
-            . $uuid->getClockSeqLowHex() . '-'
-            . $uuid->getNodeHex()
+                . $uuid->getTimeMidHex() . '-'
+                . $uuid->getTimeHiAndVersionHex() . '-'
+                . $uuid->getClockSeqHiAndReservedHex()
+                . $uuid->getClockSeqLowHex() . '-'
+                . $uuid->getNodeHex()
         );
 
         $this->assertSame(
             (string) $uuid,
             $uuid->getTimeLowHex() . '-'
-            . $uuid->getTimeMidHex() . '-'
-            . $uuid->getTimeHiAndVersionHex() . '-'
-            . $uuid->getClockSeqHiAndReservedHex()
-            . $uuid->getClockSeqLowHex() . '-'
-            . $uuid->getNodeHex()
+                . $uuid->getTimeMidHex() . '-'
+                . $uuid->getTimeHiAndVersionHex() . '-'
+                . $uuid->getClockSeqHiAndReservedHex()
+                . $uuid->getClockSeqLowHex() . '-'
+                . $uuid->getNodeHex()
         );
 
         $this->assertSame(2, $uuid->getVariant());
@@ -234,6 +235,30 @@ class ExpectedBehaviorTest extends TestCase
 
         $serialized = serialize($uuid);
         $unserialized = unserialize($serialized);
+
+        $this->assertSame(0, $uuid->compareTo($unserialized));
+        $this->assertTrue($uuid->equals($unserialized));
+        $this->assertSame("\"{$string}\"", json_encode($uuid));
+    }
+
+    /**
+     * @dataProvider provideFromStringInteger
+     */
+    public function testSerializationWithOrderedTimeCodec($string)
+    {
+        $factory = new UuidFactory();
+        $factory->setCodec(new OrderedTimeCodec(
+            $factory->getUuidBuilder()
+        ));
+
+        $previousFactory = Uuid::getFactory();
+        Uuid::setFactory($factory);
+        $uuid = Uuid::fromString($string);
+
+        $serialized = serialize($uuid);
+        $unserialized = unserialize($serialized);
+
+        Uuid::setFactory($previousFactory);
 
         $this->assertSame(0, $uuid->compareTo($unserialized));
         $this->assertTrue($uuid->equals($unserialized));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Provide a fix to the issue https://github.com/ramsey/uuid/issues/494

## Description
I updated the serialize method to take into account the configured codex.

## Motivation and context
Fix issue https://github.com/ramsey/uuid/issues/494, the serialisation method didn't consider the configured codec.

## How has this been tested?
A new test was added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
