### PR TITLE
Improve return type of UuidInterface::compareTo()

### DIFF
--- a/src/UuidInterface.php
+++ b/src/UuidInterface.php
@@ -46,7 +46,7 @@ interface UuidInterface extends
      *
      * @param UuidInterface $other The UUID to compare
      *
-     * @return int -1, 0, or 1 if the UUID is less than, equal to, or greater than $other
+     * @return int<-1,1> -1, 0, or 1 if the UUID is less than, equal to, or greater than $other
      */
     public function compareTo(UuidInterface $other): int;
 


### PR DESCRIPTION
PHPStan can reports some false positives without this.