### PR TITLE
feat: Support brick/math v0.12

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,6 +79,12 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+        include:
+          # Keep the locked version by default
+          - dependency-versions: "locked"
+          # For PHP 8.0, installing with --prefer-highest to use brick/math v0.11
+          - php-version: "8.0"
+            dependency-versions: "highest"
 
     steps:
       - name: "Checkout repository"
@@ -99,6 +105,8 @@ jobs:
 
       - name: "Install dependencies (Composer)"
         uses: "ramsey/composer-install@v2"
+        with:
+          dependency-versions: "${{ matrix.dependency-versions }}"
 
       - name: "Run PHPBench"
         run: "composer phpbench -- --ansi"
@@ -151,6 +159,12 @@ jobs:
         operating-system:
           - "ubuntu-latest"
           - "windows-latest"
+        include:
+          # Keep the locked version by default
+          - dependency-versions: "locked"
+          # For PHP 8.0, installing with --prefer-highest to use brick/math v0.11
+          - php-version: "8.0"
+            dependency-versions: "highest"
 
     steps:
       - name: "Configure Git (for Windows)"
@@ -179,7 +193,7 @@ jobs:
       - name: "Install dependencies (Composer)"
         uses: "ramsey/composer-install@v2"
         with:
-          composer-options: "${{ matrix.composer-options }}"
+          dependency-versions: "${{ matrix.dependency-versions }}"
 
       - name: "Run unit tests (PHPUnit)"
         run: "./vendor/bin/phpunit --verbose --colors=always --no-coverage"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11",
+        "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
         "ramsey/collection": "^1.2 || ^2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,29 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a0cfb78275fbdcb1744fc79f1d5fb66",
+    "content-hash": "d096188f435f9df9336415308e9e4938",
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.11.0",
+            "version": "0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478"
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/0ad82ce168c82ba30d1c01ec86116ab52f589478",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478",
+                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^9.0",
-                "vimeo/psalm": "5.0.0"
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "5.16.0"
             },
             "type": "library",
             "autoload": {
@@ -46,12 +46,17 @@
                 "arithmetic",
                 "bigdecimal",
                 "bignum",
+                "bignumber",
                 "brick",
-                "math"
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.11.0"
+                "source": "https://github.com/brick/math/tree/0.12.1"
             },
             "funding": [
                 {
@@ -59,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-15T23:15:59+00:00"
+            "time": "2023-11-29T23:19:16+00:00"
         },
         {
             "name": "ramsey/collection",
@@ -7363,5 +7368,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,7 +4,8 @@
        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
        errorLevel="1"
        cacheDirectory="./build/cache/psalm"
-       errorBaseline="psalm-baseline.xml">
+       errorBaseline="psalm-baseline.xml"
+       phpVersion="8.1">
 
     <projectFiles>
         <directory name="./src" />

--- a/src/Math/BrickMathCalculator.php
+++ b/src/Math/BrickMathCalculator.php
@@ -136,9 +136,11 @@ final class BrickMathCalculator implements CalculatorInterface
 
     /**
      * Maps ramsey/uuid rounding modes to those used by brick/math
+     *
+     * @return BrickMathRounding::*
      */
-    private function getBrickRoundingMode(int $roundingMode): int
+    private function getBrickRoundingMode(int $roundingMode)
     {
-        return self::ROUNDING_MODE_MAP[$roundingMode] ?? 0;
+        return self::ROUNDING_MODE_MAP[$roundingMode] ?? BrickMathRounding::UNNECESSARY;
     }
 }


### PR DESCRIPTION
Closes #525 

## Description
This pull request adds support for brick/math v0.12.

## Motivation and context
brick/math v0.12 has been released.
ramsey/uuid requires < 0.12 for now, so we can not upgrade brick/math until ramsey/uuid supports it.

## How has this been tested?
Static Analysis + Unit Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
