### PR TITLE
Prevent PHPStan error: 'Uuid::fromString() on a separate line has no effect.'

### DIFF
--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -19,6 +19,7 @@ use DateTimeInterface;
 use Ramsey\Uuid\Codec\CodecInterface;
 use Ramsey\Uuid\Converter\NumberConverterInterface;
 use Ramsey\Uuid\Converter\TimeConverterInterface;
+use Ramsey\Uuid\Exception\InvalidArgumentException;
 use Ramsey\Uuid\Exception\UnsupportedOperationException;
 use Ramsey\Uuid\Fields\FieldsInterface;
 use Ramsey\Uuid\Lazy\LazyUuidFromString;
@@ -436,9 +437,10 @@ class Uuid implements UuidInterface
      * @return UuidInterface A UuidInterface instance created from a binary
      *     string representation
      *
+     * @throws InvalidArgumentException
+     *
      * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
      *             but under constant factory setups, this method operates in functionally pure manners
-     *
      * @psalm-suppress ImpureStaticProperty we know that the factory being replaced can lead to massive
      *                                      havoc across all consumers: that should never happen, and
      *                                      is generally to be discouraged. Until the factory is kept
@@ -474,9 +476,10 @@ class Uuid implements UuidInterface
      * @return UuidInterface A UuidInterface instance created from a hexadecimal
      *     string representation
      *
+     * @throws InvalidArgumentException
+     *
      * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
      *             but under constant factory setups, this method operates in functionally pure manners
-     *
      * @psalm-suppress ImpureStaticProperty we know that the factory being replaced can lead to massive
      *                                      havoc across all consumers: that should never happen, and
      *                                      is generally to be discouraged. Until the factory is kept
@@ -523,6 +526,8 @@ class Uuid implements UuidInterface
      * @return UuidInterface A UuidInterface instance created from the Hexadecimal
      * object representing a hexadecimal number
      *
+     * @throws InvalidArgumentException
+     *
      * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
      *             but under constant factory setups, this method operates in functionally pure manners
      * @psalm-suppress MixedInferredReturnType,MixedReturnStatement
@@ -549,6 +554,8 @@ class Uuid implements UuidInterface
      *
      * @return UuidInterface A UuidInterface instance created from the string
      *     representation of a 128-bit integer
+     *
+     * @throws InvalidArgumentException
      *
      * @psalm-pure note: changing the internal factory is an edge case not covered by purity invariants,
      *             but under constant factory setups, this method operates in functionally pure manners


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
in a codebase which uses this lib like 

```php
<?php

require 'vendor/autoload.php';

function doFoo(string $id):void {
    try {
        \Ramsey\Uuid\Uuid::fromString($id);
    } catch (InvalidArgumentException) {
        throw new InvalidArgumentException('Invalid UUID string provided: ' . $id . '.');
    }
}
```

... and covers it with PHPStan, before this PR we ran into this error:

```
vendor/bin/phpstan analyze test.php --debug
Note: Using configuration file /Users/staabm/workspace/uuid/phpstan.neon.dist.
/Users/staabm/workspace/uuid/test.php
 ------ ---------------------------------------------------------------------------------------- 
  Line   test.php                                                                                
 ------ ---------------------------------------------------------------------------------------- 
  7      Call to static method Ramsey\Uuid\Uuid::fromString() on a separate line has no effect.  
 ------ ---------------------------------------------------------------------------------------- 


                                                                                                                        
 [ERROR] Found 1 error                                                                                                                                                                                                                     
```

after this PR the error is gone.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes a PHPStan upstream reported ramsey/uuid issue: https://github.com/phpstan/phpstan/issues/10819

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

locally by running the mentioned example with PHPStan

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
