### PR TITLE
Add __serialize and __unserialize methods to UuidInterface

### DIFF
--- a/src/UuidInterface.php
+++ b/src/UuidInterface.php
@@ -111,4 +111,14 @@ interface UuidInterface extends JsonSerializable, Stringable
      * @psalm-return non-empty-string
      */
     public function toString(): string;
+
+    /**
+     * @return array{bytes: string}
+     */
+    public function __serialize(): array;
+
+    /**
+     * @param array{bytes?: string} $data
+     */
+    public function __unserialize(array $data): void;
 }


### PR DESCRIPTION
With PHP 8.1 and beyond, the deprecation of certain serialization techniques has been a challenge for developers using `UuidInterface` as mocking classes. By implementing these methods, we can ensure that our tests remain functional without generating deprecated notices, thus enhancing the developer experience. For more information, refer to the [PHP 8.1 Serialization Deprecation](https://php.watch/versions/8.1/serializable-deprecated).