### PR TITLE
Updated Factory Interface Methods

### DIFF
--- a/src/UuidFactoryInterface.php
+++ b/src/UuidFactoryInterface.php
@@ -154,4 +154,31 @@ interface UuidFactoryInterface
      * @return UuidInterface A UuidInterface instance that represents a version 6 UUID
      */
     public function uuid6(?Hexadecimal $node = null, ?int $clockSeq = null): UuidInterface;
+
+    /**
+     * Returns a version 7 (Unix Epoch time) UUID
+     *
+     * @param DateTimeInterface | null $dateTime An optional date/time from which to create the version 7 UUID. If not
+     *     provided, the UUID is generated using the current date/time.
+     *
+     * @return UuidInterface A UuidInterface instance that represents a version 7 UUID
+     */
+    public function uuid7(?DateTimeInterface $dateTime = null): UuidInterface;
+
+    /**
+     * Returns a version 8 (custom format) UUID
+     *
+     * The bytes provided may contain any value according to your application's needs. Be aware, however, that other
+     * applications may not understand the semantics of the value.
+     *
+     * @param non-empty-string $bytes A 16-byte octet string. This is an open blob of data that you may fill with 128
+     *     bits of information. Be aware, however, bits 48 through 51 will be replaced with the UUID version field, and
+     *     bits 64 and 65 will be replaced with the UUID variant. You MUST NOT rely on these bits for your application
+     *     needs.
+     *
+     * @return UuidInterface A UuidInterface instance that represents a version 8 UUID
+     *
+     * @pure
+     */
+    public function uuid8(string $bytes): UuidInterface;
 }


### PR DESCRIPTION
* Adds the existing factory methods for `uuid7()` and `uuid8()` to the interface.

## Description

`UuidFactoryInterface` was intentionally left unchanged in v4 releases when v7 & v8 methods were added to avoid a BC. With version 5 of this library the interface should be updated (or a new interface added).

## Motivation and context
The interface(s) will now correctly reflect the available methods from the factory.

## How has this been tested?
* Tested in-place with an existing `v4` installation
* Verified fixes the PHPStan complaint for `method.notFound`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
