### PR TITLE
[5.x] Upgrade `brick/math` to support versions ^0.14.2–^0.17

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: "Downgrade brick/math in lock file, to test compatibility with older versions"
         run: |
-          composer update brick/math:"0.11.0"
+          composer update brick/math:"0.14.2"
 
       - name: "Install dependencies (Composer)"
         uses: "ramsey/composer-install@v3"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "brick/math": "^0.14.2 || ^0.15 || ^0.16"
+        "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17"
     },
     "require-dev": {
         "captainhook/captainhook": "^5.25",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "brick/math": "^0.11 || ^0.12 || ^0.13 || ^0.14"
+        "brick/math": "^0.14.2 || ^0.15 || ^0.16"
     },
     "require-dev": {
         "captainhook/captainhook": "^5.25",

--- a/src/Math/BrickMathCalculator.php
+++ b/src/Math/BrickMathCalculator.php
@@ -145,11 +145,9 @@ final class BrickMathCalculator implements CalculatorInterface
 
     /**
      * Maps ramsey/uuid rounding modes to those used by brick/math
-     *
-     * @return BrickMathRounding::*
      */
-    private function getBrickRoundingMode(int $roundingMode)
+    private function getBrickRoundingMode(int $roundingMode): BrickMathRounding
     {
-        return self::ROUNDING_MODE_MAP[$roundingMode] ?? BrickMathRounding::UNNECESSARY;
+        return self::ROUNDING_MODE_MAP[$roundingMode] ?? BrickMathRounding::Unnecessary;
     }
 }

--- a/src/Math/BrickMathCalculator.php
+++ b/src/Math/BrickMathCalculator.php
@@ -32,16 +32,16 @@ use Ramsey\Uuid\Type\NumberInterface;
 final class BrickMathCalculator implements CalculatorInterface
 {
     private const ROUNDING_MODE_MAP = [
-        RoundingMode::UNNECESSARY => BrickMathRounding::UNNECESSARY,
-        RoundingMode::UP => BrickMathRounding::UP,
-        RoundingMode::DOWN => BrickMathRounding::DOWN,
-        RoundingMode::CEILING => BrickMathRounding::CEILING,
-        RoundingMode::FLOOR => BrickMathRounding::FLOOR,
-        RoundingMode::HALF_UP => BrickMathRounding::HALF_UP,
-        RoundingMode::HALF_DOWN => BrickMathRounding::HALF_DOWN,
-        RoundingMode::HALF_CEILING => BrickMathRounding::HALF_CEILING,
-        RoundingMode::HALF_FLOOR => BrickMathRounding::HALF_FLOOR,
-        RoundingMode::HALF_EVEN => BrickMathRounding::HALF_EVEN,
+        RoundingMode::UNNECESSARY => BrickMathRounding::Unnecessary,
+        RoundingMode::UP => BrickMathRounding::Up,
+        RoundingMode::DOWN => BrickMathRounding::Down,
+        RoundingMode::CEILING => BrickMathRounding::Ceiling,
+        RoundingMode::FLOOR => BrickMathRounding::Floor,
+        RoundingMode::HALF_UP => BrickMathRounding::HalfUp,
+        RoundingMode::HALF_DOWN => BrickMathRounding::HalfDown,
+        RoundingMode::HALF_CEILING => BrickMathRounding::HalfCeiling,
+        RoundingMode::HALF_FLOOR => BrickMathRounding::HalfFloor,
+        RoundingMode::HALF_EVEN => BrickMathRounding::HalfEven,
     ];
 
     public function add(NumberInterface $augend, NumberInterface ...$addends): NumberInterface

--- a/src/Type/Time.php
+++ b/src/Type/Time.php
@@ -63,9 +63,10 @@ final class Time implements TypeInterface
     {
         /** @var numeric-string $microseconds */
         $microseconds = sprintf('%06s', $this->microseconds->toString());
+        /** @var numeric-string $time */
+        $time = "{$this->seconds->toString()}.$microseconds";
 
-        /** @var numeric-string */
-        return "{$this->seconds->toString()}.$microseconds";
+        return $time;
     }
 
     /**

--- a/tests/Converter/Time/PhpTimeConverterTest.php
+++ b/tests/Converter/Time/PhpTimeConverterTest.php
@@ -38,10 +38,10 @@ class PhpTimeConverterTest extends TestCase
 
         $converter = new PhpTimeConverter();
 
-        /** @var numeric-string $numericSeconds */
+        /** @var non-empty-string&numeric-string $numericSeconds */
         $numericSeconds = (string) $seconds;
 
-        /** @var numeric-string $numericMicroseconds */
+        /** @var non-empty-string&numeric-string $numericMicroseconds */
         $numericMicroseconds = (string) $microseconds;
 
         $returned = $converter->calculateTime($numericSeconds, $numericMicroseconds);

--- a/tests/Math/BrickMathCalculatorTest.php
+++ b/tests/Math/BrickMathCalculatorTest.php
@@ -96,7 +96,9 @@ class BrickMathCalculatorTest extends TestCase
         $calculator = new BrickMathCalculator();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('"o" is not a valid character in base 16');
+        $this->expectExceptionMessageMatches(
+            '/(\"o\" is not a valid character in base 16\.|Character \"o\" is not valid in base 16\.)/'
+        );
 
         $calculator->fromBase('foobar', 16);
     }

--- a/tests/UuidTest.php
+++ b/tests/UuidTest.php
@@ -1051,8 +1051,8 @@ class UuidTest extends TestCase
                 );
 
                 // Assert that the time matches
-                $usecAdd = BigDecimal::of($usec)->dividedBy('1000000', 14, RoundingMode::HALF_UP);
-                $testTime = BigDecimal::of($currentTime)->plus($usecAdd)->toScale(0, RoundingMode::DOWN);
+                $usecAdd = BigDecimal::of($usec)->dividedBy('1000000', 14, RoundingMode::HalfUp);
+                $testTime = BigDecimal::of($currentTime)->plus($usecAdd)->toScale(0, RoundingMode::Down);
                 $this->assertSame((string) $testTime, (string) $uuid64->getDateTime()->getTimestamp());
                 $this->assertSame((string) $testTime, (string) $uuid32->getDateTime()->getTimestamp());
             }


### PR DESCRIPTION
## Description
This PR upgrades the `brick/math` dependency and updates the codebase to use the new rounding mode constants introduced in version 0.14.2.

The `5.x` branch was targeted to keep the implementation clean and avoid legacy constraints.

Key changes:
- **Breaking:** Updated `composer.json` to require `brick/math` `^0.14.2 || ^0.15 || ^0.16 || ^0.17`, dropping support for `^0.11–^0.13`.
- Migrated all usages of `Brick\Math\RoundingMode` constants from SCREAMING_SNAKE_CASE (deprecated) to PascalCase (e.g., `HALF_UP` -> `HalfUp`).
- Updated CI workflow to test against the new minimum version (0.14.2).
- Adjusted `BrickMathCalculatorTest` to handle variations in exception messages between different `brick/math` versions.
- Refactored `Ramsey\Uuid\Type\Time::toString()` to ensure it returns a `numeric-string`, addressing a PHPStan static analysis error.

## Motivation and context
`brick/math` 0.14.2 introduced PascalCase constants and deprecated the old ones. The old constants are removed in version 0.15. This update ensures the library remains compatible with current and future versions of the dependency. Additionally, it fixes a type-hinting issue reported by PHPStan in the `Time` class.

## How has this been tested?
- Ran unit tests via `vendor/bin/phpunit` to ensure all functionality remains intact.
- Ran PHPStan static analysis via `composer dev:analyze` to verify the fix in `src/Type/Time.php`.
- Verified compatibility with the new minimum version of `brick/math` (0.14.2) in the CI environment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.