### PR TITLE
Fix: Use `foreach` instead of `array_map()` in `UuidStringConversionBench`

### DIFF
--- a/tests/benchmark/UuidStringConversionBench.php
+++ b/tests/benchmark/UuidStringConversionBench.php
@@ -223,9 +223,9 @@ final class UuidStringConversionBench
 
     public function benchStringConversionOfPromiscuousUuids(): void
     {
-        array_map(static function (UuidInterface $uuid): string {
-            return $uuid->toString();
-        }, $this->promiscuousUuids);
+        foreach ($this->promiscuousUuids as $uuid) {
+            $uuid->toString();
+        }
     }
 
     public function benchBytesConversionOfTinyUuid(): void
@@ -245,8 +245,8 @@ final class UuidStringConversionBench
 
     public function benchBytesConversionOfPromiscuousUuids(): void
     {
-        array_map(static function (UuidInterface $uuid): string {
-            return $uuid->getBytes();
-        }, $this->promiscuousUuids);
+        foreach ($this->promiscuousUuids as $uuid) {
+            $uuid->getBytes();
+        }
     }
 }


### PR DESCRIPTION
This pull request

- [x] uses `foreach` instead of `array_map()` in `UuidStringConversionBench`

❗ Blocks #642.

💁‍♂️ Maybe it would be better to run the

- `coding-standards`
- `static-analysis`

with locked dependencies instead?