### PR TITLE
Fix uncaught InvalidArgumentException in PhpTimeConverter for timestamps just before the Unix epoch

### DIFF
--- a/src/Converter/Time/PhpTimeConverter.php
+++ b/src/Converter/Time/PhpTimeConverter.php
@@ -26,6 +26,7 @@ use function dechex;
 use function explode;
 use function is_float;
 use function is_int;
+use function str_contains;
 use function str_pad;
 use function strlen;
 use function substr;
@@ -140,6 +141,12 @@ class PhpTimeConverter implements TimeConverterInterface
 
         if (count($split) === 1) {
             return ['sec' => $split[0], 'usec' => '0'];
+        }
+
+        // Near zero PHP renders the float in scientific notation ("-1.0E-6"), whose
+        // exponent would be misparsed as microseconds; fall back instead.
+        if (str_contains($split[1], 'E')) {
+            return [];
         }
 
         // If the microseconds are less than six characters AND the length of the number is greater than or equal to the

--- a/tests/Converter/Time/PhpTimeConverterTest.php
+++ b/tests/Converter/Time/PhpTimeConverterTest.php
@@ -133,6 +133,14 @@ class PhpTimeConverterTest extends TestCase
                 'unixTimestamp' => '0',
                 'microseconds' => '0',
             ],
+
+            // One microsecond before the epoch: PHP renders "-1.0E-6", which must not
+            // be misparsed as microseconds.
+            [
+                'uuidTimestamp' => new Hexadecimal('1b21dd213813ff6'),
+                'unixTimestamp' => '0',
+                'microseconds' => '1',
+            ],
         ];
     }
 


### PR DESCRIPTION

## Problem

Problem
-------

`PhpTimeConverter::convertTime()` throws an uncaught
`Ramsey\Uuid\Exception\InvalidArgumentException` for a version 1 (or
version 6) UUID whose embedded timestamp falls within roughly 100
microseconds of the Unix epoch, on the "before" side (e.g.
1969-12-31 23:59:59.999999). Such timestamps are entirely valid: v1/v6
UUIDs can encode any instant from 1582-10-15 onward, well before 1970.

Reproduction on a clean checkout:

    $ php -r '
    require "vendor/autoload.php";
    use Ramsey\Uuid\Uuid;
    $uuid = Uuid::fromDateTime(new DateTimeImmutable("1969-12-31 23:59:59.999999"));
    $uuid->getDateTime();
    '

    PHP Fatal error:  Uncaught Ramsey\Uuid\Exception\InvalidArgumentException:
    Value must be a signed integer or a string containing only digits 0-9
    and, optionally, a sign (+ or -)
    in src/Type/Integer.php:134

Root cause
----------

`PhpTimeConverter::convertTime()` divides the 100-nanosecond interval
count by `SECOND_INTERVALS` (src/Converter/Time/PhpTimeConverter.php:113),
producing a native PHP float, then hands it to `splitTime()`
(src/Converter/Time/PhpTimeConverter.php:131) which parses that float's
string form by splitting on the decimal point.

For magnitudes below about 1e-4, PHP renders floats in scientific
notation instead of fixed-point decimal, e.g. `(string) -1.0E-6` is
`"-1.0E-6"`, not `"-0.000001"`. `splitTime()` did not anticipate this
and split `"-1.0E-6"` into a bogus microseconds fragment (`"0E-6"`),
which after right-padding became the malformed string `"0E-600"`. That
string was then passed to `Type\Integer`'s constructor
(src/Type/Integer.php:134), which rejects anything that is not a plain
signed digit string and throws.

Fix
---

`splitTime()` now detects the scientific-notation marker (`E`) in the
fractional part and returns an empty array in that case, exactly like
the existing precision-loss guard a few lines below it. An empty
return value is the method's established signal to defer to the
arbitrary-precision fallback converter (`GenericTimeConverter`, which
uses `brick/math` decimals and is unaffected by this float formatting
quirk), so `convertTime()` (src/Converter/Time/PhpTimeConverter.php:116-117)
transparently retries there instead of propagating a malformed value.

This is intentionally narrow: it only prevents the crash. It does not
change the (separate, long-standing, and already covered by
`UuidV1Test::testGetDateTimeProperlyHandlesLongMicroseconds`) rounding
behavior for timestamps within one second of the epoch.

Verification
------------

    $ composer install
    $ vendor/bin/phpunit
    Tests: 2023, Assertions: 88400, Skipped: 7.  (exit 0)
    (the 7 skips are pre-existing: "Extension uuid is required", unrelated
    to this change)

    $ vendor/bin/phpstan analyse
    [OK] No errors  (exit 0)

    $ composer dev:lint:style
    (exit 0)

A new data set was added to the existing `provideConvertTime()`
provider in `tests/Converter/Time/PhpTimeConverterTest.php` for the
UUID timestamp hex `1b21dd213813ff6` (one microsecond before the Unix
epoch). Reverting only the fix in `splitTime()` while keeping this
test reproduces the exact exception above:

    1) Ramsey\Uuid\Test\Converter\Time\PhpTimeConverterTest::testConvertTime
       with data set #6 (..., '0', '1')
    Ramsey\Uuid\Exception\InvalidArgumentException: Value must be a signed
    integer or a string containing only digits 0-9 and, optionally, a sign
    (+ or -)
